### PR TITLE
Migrate examples and docs to implicit fork syntax

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ When writing or generating NeuroScript (.ns) files:
 - Binding blocks use `context:` keyword (not `let:`), with optional annotations: `@lazy`, `@static`, `@global`
 - Recursive bindings require `@lazy` annotation with arguments that change (e.g., `depth - 1`)
 - Only one variadic dimension per shape (e.g., `[*shape, dim]` works, `[*a, *b]` does not)
-- Fork (2-way) and Fork3 (3-way) are the available split primitives — no Fork4+
+- Implicit fork is preferred for splitting: `in -> (a, b, c)` — any single output → N-way tuple. Explicit Fork/Fork3 only for named port access
 - Shape dimension expressions support +, -, *, / but solver handles only simple single-unknown equations
 - Always validate generated .ns files with the CLI before considering work complete
 
@@ -331,7 +331,8 @@ Two types:
 
 - Simple: `in -> Linear(512, 256) -> out`
 - Multi-line: Indentation creates pipeline continuation
-- Tuple unpacking: `in -> Fork() -> (main, skip)` creates two named references
+- Implicit fork (preferred): `in -> (main, skip)` — single output auto-replicates to N tuple bindings
+- Explicit Fork (for named ports only): `in -> Fork() -> f` then `f.left`, `f.right`
 - Port access: `main -> MLP(dim) -> processed`
 
 ### Shapes
@@ -350,13 +351,19 @@ Two types:
 - Keywords are defined as pest rules with `!ident_cont` negative lookahead to prevent partial matches
 - Indentation significance is handled during AST building, not in the grammar itself
 
-### Tuple Unpacking Grammar
+### Tuple Unpacking & Implicit Fork
 
 ```rust
-// WRONG: Tuple unpacking only works for port references in connections
-in -> Fork() -> (a, b, c)  // Creates references a, b, c
+// Implicit fork (v0.3.0+) — preferred for splitting tensors
+in -> (a, b, c)        // Single output auto-replicates to all bindings
+in -> (main, skip)     // Any number of outputs supported
 
-// RIGHT: Not for inline calls
+// Explicit Fork — only when you need named port access
+in -> Fork() -> f
+f.left -> ...
+f.right -> ...
+
+// NOT for inline calls
 Linear(dim, dim * 4)  // Call with args, not tuple
 ```
 

--- a/examples/codegen_demo/residual.ns
+++ b/examples/codegen_demo/residual.ns
@@ -38,6 +38,6 @@ neuron Residual(dim):
   in: [*, dim]
   out: [*, dim]
   graph:
-    in -> Fork() -> (main, skip)
+    in -> (main, skip)
     main -> MLP(dim) -> processed
     (processed, skip) -> Add() -> out

--- a/examples/primitives/activations.ns
+++ b/examples/primitives/activations.ns
@@ -80,7 +80,7 @@ neuron GatedFFN(dim):
     in: [*, dim]
     out: [*, dim]
     graph:
-        in -> Fork() -> (gate_path, value_path)
+        in -> (gate_path, value_path)
         gate_path -> Linear(dim, dim * 4) -> SiLU() -> gate
         value_path -> Linear(dim, dim * 4) -> value
         (gate, value) -> Multiply() -> Linear(dim * 4, dim) -> out

--- a/examples/primitives/attention.ns
+++ b/examples/primitives/attention.ns
@@ -21,7 +21,7 @@ neuron SelfAttentionBlock(d_model, num_heads):
     in: [batch, seq, d_model]
     out: [batch, seq, d_model]
     graph:
-        in -> Fork() -> (main, skip)
+        in -> (main, skip)
         main ->
             LayerNorm(d_model)
             MultiHeadSelfAttention(d_model, num_heads)
@@ -39,7 +39,7 @@ neuron CrossAttentionBlock(d_model):
         query -> Linear(d_model, d_model) -> q
 
         # Project key and value from memory
-        memory -> Fork() -> (k_path, v_path)
+        memory -> (k_path, v_path)
         k_path -> Linear(d_model, d_model) -> k
         v_path -> Linear(d_model, d_model) -> v
 
@@ -51,7 +51,7 @@ neuron PreNormAttention(d_model, num_heads):
     in: [batch, seq, d_model]
     out: [batch, seq, d_model]
     graph:
-        in -> Fork() -> (main, skip)
+        in -> (main, skip)
         main ->
             LayerNorm(d_model)
             MultiHeadSelfAttention(d_model, num_heads)
@@ -63,7 +63,7 @@ neuron PostNormAttention(dim, num_heads):
     in: [batch, seq, dim]
     out: [batch, seq, dim]
     graph:
-        in -> Fork() -> (main, skip)
+        in -> (main, skip)
         main -> MultiHeadSelfAttention(dim, num_heads) -> attn_out
         (attn_out, skip) -> Add() -> LayerNorm(dim) -> out
 
@@ -73,7 +73,7 @@ neuron TransformerBlock(dim, num_heads):
     out: [batch, seq, dim]
     graph:
         # Attention sublayer
-        in -> Fork() -> (attn_main, attn_skip)
+        in -> (attn_main, attn_skip)
         attn_main ->
             LayerNorm(dim)
             MultiHeadSelfAttention(dim, num_heads)
@@ -81,7 +81,7 @@ neuron TransformerBlock(dim, num_heads):
         (attn_out, attn_skip) -> Add() -> attn_residual
 
         # FFN sublayer
-        attn_residual -> Fork() -> (ffn_main, ffn_skip)
+        attn_residual -> (ffn_main, ffn_skip)
         ffn_main ->
             LayerNorm(dim)
             Linear(dim, dim * 4)

--- a/examples/primitives/normalization.ns
+++ b/examples/primitives/normalization.ns
@@ -37,7 +37,7 @@ neuron PreNormBlock(dim):
     in: [*, seq, dim]
     out: [*, seq, dim]
     graph:
-        in -> Fork() -> (main, skip)
+        in -> (main, skip)
         main ->
             LayerNorm(dim)
             Linear(dim, dim)
@@ -49,7 +49,7 @@ neuron PostNormBlock(dim):
     in: [*, seq, dim]
     out: [*, seq, dim]
     graph:
-        in -> Fork() -> (main, skip)
+        in -> (main, skip)
         main -> Linear(dim, dim) -> processed
         (processed, skip) -> Add() -> LayerNorm(dim) -> out
 
@@ -58,7 +58,7 @@ neuron LLaMAStyleBlock(dim):
     in: [*, seq, dim]
     out: [*, seq, dim]
     graph:
-        in -> Fork() -> (main, skip)
+        in -> (main, skip)
         main ->
             RMSNorm(dim)
             Linear(dim, dim * 4)

--- a/examples/primitives/operations.ns
+++ b/examples/primitives/operations.ns
@@ -47,7 +47,7 @@ neuron ResidualAdd(dim):
     in: [*, dim]
     out: [*, dim]
     graph:
-        in -> Fork() -> (main, skip)
+        in -> (main, skip)
         main -> Linear(dim, dim) -> processed
         (processed, skip) -> Add() -> out
 
@@ -56,7 +56,7 @@ neuron GatedUnit(dim, hidden_dim):
     in: [*, dim]
     out: [*, dim]
     graph:
-        in -> Fork() -> (gate_path, value_path)
+        in -> (gate_path, value_path)
         gate_path -> Linear(dim, hidden_dim) -> SiLU() -> gate
         value_path -> Linear(dim, hidden_dim) -> value
         (gate, value) -> Multiply() -> Linear(hidden_dim, dim) -> out
@@ -86,7 +86,7 @@ neuron WeightedResidual(dim):
     in: [*, dim]
     out: [*, dim]
     graph:
-        in -> Fork() -> (main, skip)
+        in -> (main, skip)
         main -> Linear(dim, dim) -> processed
         processed -> Scale(dim) -> scaled
         (scaled, skip) -> Add() -> out
@@ -96,7 +96,7 @@ neuron ComplexOperation(dim):
     in: [*, dim]
     out: [*, dim]
     graph:
-        in -> Fork() -> (path1, path2)
+        in -> (path1, path2)
 
         # Path 1: Linear + bias + scale
         path1 ->

--- a/examples/primitives/structural.ns
+++ b/examples/primitives/structural.ns
@@ -71,7 +71,7 @@ neuron ResidualBlock(dim):
     in: [*, dim]
     out: [*, dim]
     graph:
-        in -> Fork() -> (main, skip)
+        in -> (main, skip)
         main -> Linear(dim, dim) -> processed
         (processed, skip) -> Add() -> out
 
@@ -80,7 +80,7 @@ neuron ThreePathProcessor(dim):
     in: [*, dim]
     out: [*, dim * 3]
     graph:
-        in -> Fork3() -> (p1, p2, p3)
+        in -> (p1, p2, p3)
         p1 -> Linear(dim, dim) -> out1
         p2 -> Linear(dim, dim) -> out2
         p3 -> Linear(dim, dim) -> out3

--- a/examples/real_world/llama_rope.ns
+++ b/examples/real_world/llama_rope.ns
@@ -41,7 +41,7 @@ neuron SwiGLU(dim, hidden_dim):
     in: [batch, seq, dim]
     out: [batch, seq, dim]
     graph:
-        in -> Fork() -> (gate_path, val_path)
+        in -> (gate_path, val_path)
         
         gate_path -> Linear(dim, hidden_dim) -> SiLU() -> gate
         val_path -> Linear(dim, hidden_dim) -> val
@@ -55,12 +55,12 @@ neuron LlamaBlock(dim, num_heads, intermediate_size):
     out: [batch, seq, dim]
     graph:
         # Pre-norm Attention with Residual
-        in -> Fork() -> (skip1, norm1)
+        in -> (skip1, norm1)
         norm1 -> RMSNorm(dim) -> LlamaRotaryAttention(dim, num_heads) -> attn_out
         (skip1, attn_out) -> Add() -> residual1
         
         # Pre-norm FFN with Residual
-        residual1 -> Fork() -> (skip2, norm2)
+        residual1 -> (skip2, norm2)
         norm2 -> RMSNorm(dim) -> SwiGLU(dim, intermediate_size) -> ffn_out
         (skip2, ffn_out) -> Add() -> out
 

--- a/examples/real_world/resnet.ns
+++ b/examples/real_world/resnet.ns
@@ -38,7 +38,7 @@ neuron ResidualBlock(channels):
     in: [*, channels, h, w]
     out: [*, channels, h, w]
     graph:
-        in -> Fork() -> (main, skip)
+        in -> (main, skip)
 
         main ->
             Conv2d(channels, channels, kernel_size=3, stride=1, padding=1)

--- a/examples/real_world/vision_transformer.ns
+++ b/examples/real_world/vision_transformer.ns
@@ -14,7 +14,7 @@ neuron ViTEncoderBlock(dim, num_heads):
     out: [batch, seq, dim]
     graph:
         # Multi-head self-attention with residual
-        in -> Fork() -> (attn_main, attn_skip)
+        in -> (attn_main, attn_skip)
         attn_main ->
             LayerNorm(dim)
             MultiHeadSelfAttention(dim, num_heads)
@@ -22,7 +22,7 @@ neuron ViTEncoderBlock(dim, num_heads):
         (attn_out, attn_skip) -> Add() -> attn_residual
 
         # Feed-forward with residual
-        attn_residual -> Fork() -> (ffn_main, ffn_skip)
+        attn_residual -> (ffn_main, ffn_skip)
         ffn_main ->
             LayerNorm(dim)
             Linear(dim, dim * 4)

--- a/examples/stdlib/attention.ns
+++ b/examples/stdlib/attention.ns
@@ -9,7 +9,7 @@ neuron AttentionBlock(dim, num_heads):
     in: [batch, seq, dim]
     out: [batch, seq, dim]
     graph:
-        in -> Fork() -> (main, skip)
+        in -> (main, skip)
         main ->
             LayerNorm(dim)
             MultiHeadSelfAttention(dim, num_heads)

--- a/examples/stdlib/feedforward.ns
+++ b/examples/stdlib/feedforward.ns
@@ -42,7 +42,7 @@ neuron GatedFFN(dim):
     in: [*shape, dim]
     out: [*shape, dim]
     graph:
-        in -> Fork() -> (gate_path, value_path)
+        in -> (gate_path, value_path)
 
         gate_path ->
             Linear(dim, dim * 4)
@@ -60,7 +60,7 @@ neuron TransformerFFNBlock(dim):
     in: [*shape, dim]
     out: [*shape, dim]
     graph:
-        in -> Fork() -> (main, skip)
+        in -> (main, skip)
         main ->
             LayerNorm(dim)
             FFN(dim)

--- a/examples/stdlib/residual.ns
+++ b/examples/stdlib/residual.ns
@@ -10,7 +10,7 @@ neuron Residual(dim):
     in: [*, dim]
     out: [*, dim]
     graph:
-        in -> Fork() -> (main, skip)
+        in -> (main, skip)
         main -> Linear(dim, dim * 4) -> GELU() -> Linear(dim * 4, dim) -> processed
         (processed, skip) -> Add() -> out
 
@@ -19,7 +19,7 @@ neuron ResidualMLP(dim):
     in: [*, dim]
     out: [*, dim]
     graph:
-        in -> Fork() -> (main, skip)
+        in -> (main, skip)
         main -> MLP(dim) -> processed
         (processed, skip) -> Add() -> out
 
@@ -28,7 +28,7 @@ neuron PreNormResidual(dim):
     in: [*, dim]
     out: [*, dim]
     graph:
-        in -> Fork() -> (main, skip)
+        in -> (main, skip)
         main ->
             LayerNorm(dim)
             Linear(dim, dim * 4)
@@ -42,7 +42,7 @@ neuron PostNormResidual(dim):
     in: [*, dim]
     out: [*, dim]
     graph:
-        in -> Fork() -> (main, skip)
+        in -> (main, skip)
         main -> Linear(dim, dim * 4) -> GELU() -> Linear(dim * 4, dim) -> processed
         (processed, skip) -> Add() -> LayerNorm(dim) -> out
 

--- a/examples/stdlib/transformer_block.ns
+++ b/examples/stdlib/transformer_block.ns
@@ -8,7 +8,7 @@ neuron TransformerBlock(dim, num_heads):
     out: [batch, seq, dim]
     graph:
         # Attention sublayer
-        in -> Fork() -> (attn_main, attn_skip)
+        in -> (attn_main, attn_skip)
         attn_main ->
             LayerNorm(dim)
             MultiHeadSelfAttention(dim, num_heads)
@@ -16,7 +16,7 @@ neuron TransformerBlock(dim, num_heads):
         (attn_out, attn_skip) -> Add() -> attn_residual
 
         # FFN sublayer
-        attn_residual -> Fork() -> (ffn_main, ffn_skip)
+        attn_residual -> (ffn_main, ffn_skip)
         ffn_main ->
             LayerNorm(dim)
             FFN(dim)

--- a/examples/stdlib/transformer_stack.ns
+++ b/examples/stdlib/transformer_stack.ns
@@ -18,14 +18,14 @@ neuron TransformerBlock(dim, num_heads):
     in: [batch, seq, dim]
     out: [batch, seq, dim]
     graph:
-        in -> Fork() -> (attn_main, attn_skip)
+        in -> (attn_main, attn_skip)
         attn_main ->
             LayerNorm(dim)
             MultiHeadSelfAttention(dim, num_heads)
             attn_out
         (attn_out, attn_skip) -> Add() -> attn_residual
 
-        attn_residual -> Fork() -> (ffn_main, ffn_skip)
+        attn_residual -> (ffn_main, ffn_skip)
         ffn_main ->
             LayerNorm(dim)
             Linear(dim, dim * 4)

--- a/examples/tutorials/02_fork_join.ns
+++ b/examples/tutorials/02_fork_join.ns
@@ -1,30 +1,34 @@
 # Category: Tutorials
-# Purpose: Demonstrate Fork primitive, tuple unpacking, and residual patterns
+# Purpose: Demonstrate implicit fork (tuple unpacking) and residual patterns
 # Doc reference: website/docs/tutorials/fork-join.mdx
+#
+# In NeuroScript v0.3.0+, forking is implicit: flowing a single output
+# into a tuple automatically duplicates the tensor. No explicit Fork()
+# or Fork3() call is needed.
 
-# Example 1: Basic Fork usage
+# Example 1: Basic Fork primitive (still available as a primitive)
 neuron SimpleFork:
     in: [*, dim]
     out a: [*, dim]
     out b: [*, dim]
     impl: core,builtin/Fork
 
-# Example 2: Tuple unpacking with Fork
+# Example 2: Implicit fork with tuple unpacking
 neuron UnpackExample(dim):
     in: [*, dim]
     out: [*, dim]
     graph:
-        # Fork creates two outputs, tuple unpacking names them
-        in -> Fork() -> (main, skip)
+        # Implicit fork: flowing into a tuple duplicates the tensor (v0.3.0+)
+        in -> (main, skip)
         main -> Linear(dim, dim) -> out
 
-# Example 3: Classic residual connection (fork + add pattern)
+# Example 3: Classic residual connection (implicit fork + add pattern)
 neuron ResidualBlock(dim):
     in: [*, dim]
     out: [*, dim]
     graph:
-        # Fork the input
-        in -> Fork() -> (main, skip)
+        # Implicit fork: the input is duplicated into main and skip
+        in -> (main, skip)
 
         # Process main path
         main ->
@@ -48,8 +52,8 @@ neuron ParallelProcessing(dim):
     in: [*, dim]
     out: [*, dim * 3]
     graph:
-        # Split into three paths
-        in -> Fork3() -> (path1, path2, path3)
+        # Implicit 3-way fork: flowing into a 3-tuple duplicates the tensor (v0.3.0+)
+        in -> (path1, path2, path3)
 
         # Process each independently
         path1 -> Linear(dim, dim) -> p1
@@ -59,28 +63,28 @@ neuron ParallelProcessing(dim):
         # Combine results
         (p1, p2, p3) -> Concat() -> out
 
-# Example 5: Nested fork pattern
+# Example 5: Nested implicit fork pattern
 neuron NestedResidual(dim):
     in: [*, dim]
     out: [*, dim]
     graph:
-        # Outer residual
-        in -> Fork() -> (outer_main, outer_skip)
+        # Outer residual (implicit fork)
+        in -> (outer_main, outer_skip)
 
-        # Inner residual on main path
-        outer_main -> Fork() -> (inner_main, inner_skip)
+        # Inner residual on main path (implicit fork)
+        outer_main -> (inner_main, inner_skip)
         inner_main -> Linear(dim, dim) -> inner_processed
         (inner_processed, inner_skip) -> Add() -> inner_sum
 
         # Outer add
         (inner_sum, outer_skip) -> Add() -> out
 
-# Example 6: Pre-activation residual (fork before normalization)
+# Example 6: Pre-activation residual (implicit fork before normalization)
 neuron PreActivationResidual(dim):
     in: [batch, dim]
     out: [batch, dim]
     graph:
-        in -> Fork() -> (main, skip)
+        in -> (main, skip)
 
         main ->
             LayerNorm(dim)

--- a/examples/tutorials/03_match_guards.ns
+++ b/examples/tutorials/03_match_guards.ns
@@ -57,7 +57,7 @@ neuron ConditionalResidual(target_dim):
         in -> match:
             # Dimension matches: use residual
             [*, d] where d == target_dim:
-                Fork() -> (main, skip)
+                (main, skip)
                 main -> Linear(d, d * 4) -> GELU() -> Linear(d * 4, d) -> processed
                 (processed, skip) -> Add() -> out
 

--- a/stdlib/MetaNeurons.ns
+++ b/stdlib/MetaNeurons.ns
@@ -3,8 +3,8 @@
 # These neurons orchestrate other neurons, providing structural
 # composition patterns for common neural network structures.
 #
-# NOTE: Simplified version - advanced features like Fork() with
-# tuple unpacking require implementation of primitive port signatures.
+# NOTE: Simplified version - advanced features like implicit fork
+# require implementation of primitive port signatures.
 # See primitives.ns for Identity() and other routing operations.
 
 /// Parallel FFN branches

--- a/stdlib/Residual.ns
+++ b/stdlib/Residual.ns
@@ -6,7 +6,7 @@
 # This is the fundamental building block of ResNets and Transformers.
 # Enables training of very deep networks by providing gradient shortcuts.
 #
-# NOTE: This simplified version does not use Fork() with tuple unpacking
+# NOTE: This simplified version does not use implicit fork with tuple unpacking
 # due to validator limitations with empty port signatures.
 # Full residual patterns will be added once primitives have proper
 # port definitions in the shape system.

--- a/stdlib/TransformerBlock.ns
+++ b/stdlib/TransformerBlock.ns
@@ -26,7 +26,7 @@ neuron TransformerBlock(dim, num_heads, d_ff):
     out: [batch, seq, dim]
     graph:
         # First residual-attention with pre-norm
-        in -> Fork() -> (skip1, attn_path)
+        in -> (skip1, attn_path)
 
         attn_path ->
             LayerNorm(dim)
@@ -38,7 +38,7 @@ neuron TransformerBlock(dim, num_heads, d_ff):
         (skip1, attn_out) -> Add() -> attn_residual
 
         # Second residual-forward with pre-norm
-        attn_residual -> Fork() -> (skip2, ffn_path)
+        attn_residual -> (skip2, ffn_path)
 
         ffn_path ->
             LayerNorm(dim)

--- a/tests/snapshots/integration_tests__codegen_residual_block.snap
+++ b/tests/snapshots/integration_tests__codegen_residual_block.snap
@@ -7,7 +7,6 @@ import torch.nn as nn
 from neuroscript_runtime.primitives.activations import GELU
 from neuroscript_runtime.primitives.linear import Linear
 from neuroscript_runtime.primitives.structural import Add
-from neuroscript_runtime.primitives.structural import Fork
 
 class MLP(nn.Module):
     def __init__(self, dim):
@@ -30,17 +29,15 @@ class Residual(nn.Module):
     def __init__(self, dim):
         super().__init__()
         self.dim = dim
-        self.add_2 = Add()
-        self.fork_0 = Fork()
-        self.m_l_p_1 = MLP(dim)
+        self.add_1 = Add()
+        self.m_l_p_0 = MLP(dim)
 
     def forward(self, x):
-        x0 = self.fork_0(x)
-        # Fork() output shape: [*, dim]
-        x1, x2 = x0
-        x3 = self.m_l_p_1(x1)
+        x0 = x
+        x1 = x
+        x2 = self.m_l_p_0(x0)
         # MLP() output shape: [*, dim]
         # Expected shape: [*, dim]
-        x4 = self.add_2((x3, x2))
+        x3 = self.add_1((x2, x1))
         # Add() output shape: [*, dim]
-        return x4
+        return x3

--- a/tests/snapshots/integration_tests__example_primitives_activations.snap
+++ b/tests/snapshots/integration_tests__example_primitives_activations.snap
@@ -35,16 +35,15 @@ neuron GatedFFN(dim):
   outputs:
     default: [*, dim]
   graph:
-    in -> Fork#9()
-    Fork#9() -> (gate_path, value_path)
-    gate_path -> Linear#10(dim, (dim * 4))
-    Linear#10(dim, (dim * 4)) -> SiLU#11()
-    SiLU#11() -> gate
-    value_path -> Linear#12(dim, (dim * 4))
-    Linear#12(dim, (dim * 4)) -> value
-    (gate, value) -> Multiply#13()
-    Multiply#13() -> Linear#14((dim * 4), dim)
-    Linear#14((dim * 4), dim) -> out
+    in -> (gate_path, value_path)
+    gate_path -> Linear#9(dim, (dim * 4))
+    Linear#9(dim, (dim * 4)) -> SiLU#10()
+    SiLU#10() -> gate
+    value_path -> Linear#11(dim, (dim * 4))
+    Linear#11(dim, (dim * 4)) -> value
+    (gate, value) -> Multiply#12()
+    Multiply#12() -> Linear#13((dim * 4), dim)
+    Linear#13((dim * 4), dim) -> out
 
 neuron Linear(in_dim, out_dim):
   inputs:

--- a/tests/snapshots/integration_tests__example_primitives_attention.snap
+++ b/tests/snapshots/integration_tests__example_primitives_attention.snap
@@ -20,16 +20,15 @@ neuron CrossAttentionBlock(d_model):
   outputs:
     default: [batch, tgt_seq, d_model]
   graph:
-    query -> Linear#4(d_model, d_model)
-    Linear#4(d_model, d_model) -> q
-    memory -> Fork#5()
-    Fork#5() -> (k_path, v_path)
-    k_path -> Linear#6(d_model, d_model)
-    Linear#6(d_model, d_model) -> k
-    v_path -> Linear#7(d_model, d_model)
-    Linear#7(d_model, d_model) -> v
-    (q, k, v) -> ScaledDotProductAttention#8(d_model)
-    ScaledDotProductAttention#8(d_model) -> out
+    query -> Linear#3(d_model, d_model)
+    Linear#3(d_model, d_model) -> q
+    memory -> (k_path, v_path)
+    k_path -> Linear#4(d_model, d_model)
+    Linear#4(d_model, d_model) -> k
+    v_path -> Linear#5(d_model, d_model)
+    Linear#5(d_model, d_model) -> v
+    (q, k, v) -> ScaledDotProductAttention#6(d_model)
+    ScaledDotProductAttention#6(d_model) -> out
 
 neuron Fork:
   inputs:
@@ -78,13 +77,12 @@ neuron PostNormAttention(dim, num_heads):
   outputs:
     default: [batch, seq, dim]
   graph:
-    in -> Fork#13()
-    Fork#13() -> (main, skip)
-    main -> MultiHeadSelfAttention#14(dim, num_heads)
-    MultiHeadSelfAttention#14(dim, num_heads) -> attn_out
-    (attn_out, skip) -> Add#15()
-    Add#15() -> LayerNorm#16(dim)
-    LayerNorm#16(dim) -> out
+    in -> (main, skip)
+    main -> MultiHeadSelfAttention#10(dim, num_heads)
+    MultiHeadSelfAttention#10(dim, num_heads) -> attn_out
+    (attn_out, skip) -> Add#11()
+    Add#11() -> LayerNorm#12(dim)
+    LayerNorm#12(dim) -> out
 
 neuron PreNormAttention(d_model, num_heads):
   inputs:
@@ -92,13 +90,12 @@ neuron PreNormAttention(d_model, num_heads):
   outputs:
     default: [batch, seq, d_model]
   graph:
-    in -> Fork#9()
-    Fork#9() -> (main, skip)
-    main -> LayerNorm#10(d_model)
-    LayerNorm#10(d_model) -> MultiHeadSelfAttention#11(d_model, num_heads)
-    MultiHeadSelfAttention#11(d_model, num_heads) -> attn_out
-    (attn_out, skip) -> Add#12()
-    Add#12() -> out
+    in -> (main, skip)
+    main -> LayerNorm#7(d_model)
+    LayerNorm#7(d_model) -> MultiHeadSelfAttention#8(d_model, num_heads)
+    MultiHeadSelfAttention#8(d_model, num_heads) -> attn_out
+    (attn_out, skip) -> Add#9()
+    Add#9() -> out
 
 neuron ScaledDotProductAttention(dim):
   inputs:
@@ -116,13 +113,12 @@ neuron SelfAttentionBlock(d_model, num_heads):
   outputs:
     default: [batch, seq, d_model]
   graph:
-    in -> Fork#0()
-    Fork#0() -> (main, skip)
-    main -> LayerNorm#1(d_model)
-    LayerNorm#1(d_model) -> MultiHeadSelfAttention#2(d_model, num_heads)
-    MultiHeadSelfAttention#2(d_model, num_heads) -> processed
-    (processed, skip) -> Add#3()
-    Add#3() -> out
+    in -> (main, skip)
+    main -> LayerNorm#0(d_model)
+    LayerNorm#0(d_model) -> MultiHeadSelfAttention#1(d_model, num_heads)
+    MultiHeadSelfAttention#1(d_model, num_heads) -> processed
+    (processed, skip) -> Add#2()
+    Add#2() -> out
 
 neuron TransformerBlock(dim, num_heads):
   inputs:
@@ -130,19 +126,17 @@ neuron TransformerBlock(dim, num_heads):
   outputs:
     default: [batch, seq, dim]
   graph:
-    in -> Fork#17()
-    Fork#17() -> (attn_main, attn_skip)
-    attn_main -> LayerNorm#18(dim)
-    LayerNorm#18(dim) -> MultiHeadSelfAttention#19(dim, num_heads)
-    MultiHeadSelfAttention#19(dim, num_heads) -> attn_out
-    (attn_out, attn_skip) -> Add#20()
-    Add#20() -> attn_residual
-    attn_residual -> Fork#21()
-    Fork#21() -> (ffn_main, ffn_skip)
-    ffn_main -> LayerNorm#22(dim)
-    LayerNorm#22(dim) -> Linear#23(dim, (dim * 4))
-    Linear#23(dim, (dim * 4)) -> GELU#24()
-    GELU#24() -> Linear#25((dim * 4), dim)
-    Linear#25((dim * 4), dim) -> ffn_out
-    (ffn_out, ffn_skip) -> Add#26()
-    Add#26() -> out
+    in -> (attn_main, attn_skip)
+    attn_main -> LayerNorm#13(dim)
+    LayerNorm#13(dim) -> MultiHeadSelfAttention#14(dim, num_heads)
+    MultiHeadSelfAttention#14(dim, num_heads) -> attn_out
+    (attn_out, attn_skip) -> Add#15()
+    Add#15() -> attn_residual
+    attn_residual -> (ffn_main, ffn_skip)
+    ffn_main -> LayerNorm#16(dim)
+    LayerNorm#16(dim) -> Linear#17(dim, (dim * 4))
+    Linear#17(dim, (dim * 4)) -> GELU#18()
+    GELU#18() -> Linear#19((dim * 4), dim)
+    Linear#19((dim * 4), dim) -> ffn_out
+    (ffn_out, ffn_skip) -> Add#20()
+    Add#20() -> out

--- a/tests/snapshots/integration_tests__example_primitives_normalization.snap
+++ b/tests/snapshots/integration_tests__example_primitives_normalization.snap
@@ -35,10 +35,10 @@ neuron ConvBlock(in_channels, out_channels):
   outputs:
     default: [*, out_channels, h, w]
   graph:
-    in -> Conv2d#14(in_channels, out_channels, kernel_size=3, padding=1)
-    Conv2d#14(in_channels, out_channels, kernel_size=3, padding=1) -> BatchNorm#15(out_channels)
-    BatchNorm#15(out_channels) -> ReLU#16()
-    ReLU#16() -> out
+    in -> Conv2d#11(in_channels, out_channels, kernel_size=3, padding=1)
+    Conv2d#11(in_channels, out_channels, kernel_size=3, padding=1) -> BatchNorm#12(out_channels)
+    BatchNorm#12(out_channels) -> ReLU#13()
+    ReLU#13() -> out
 
 neuron Fork:
   inputs:
@@ -63,10 +63,10 @@ neuron GroupNormBlock(channels, num_groups):
   outputs:
     default: [*, channels, h, w]
   graph:
-    in -> Conv2d#17(channels, channels, kernel_size=3, padding=1)
-    Conv2d#17(channels, channels, kernel_size=3, padding=1) -> GroupNorm#18(num_groups, channels)
-    GroupNorm#18(num_groups, channels) -> ReLU#19()
-    ReLU#19() -> out
+    in -> Conv2d#14(channels, channels, kernel_size=3, padding=1)
+    Conv2d#14(channels, channels, kernel_size=3, padding=1) -> GroupNorm#15(num_groups, channels)
+    GroupNorm#15(num_groups, channels) -> ReLU#16()
+    ReLU#16() -> out
 
 neuron InstanceNorm(dim):
   inputs:
@@ -82,15 +82,14 @@ neuron LLaMAStyleBlock(dim):
   outputs:
     default: [*, seq, dim]
   graph:
-    in -> Fork#8()
-    Fork#8() -> (main, skip)
-    main -> RMSNorm#9(dim)
-    RMSNorm#9(dim) -> Linear#10(dim, (dim * 4))
-    Linear#10(dim, (dim * 4)) -> SiLU#11()
-    SiLU#11() -> Linear#12((dim * 4), dim)
-    Linear#12((dim * 4), dim) -> processed
-    (processed, skip) -> Add#13()
-    Add#13() -> out
+    in -> (main, skip)
+    main -> RMSNorm#6(dim)
+    RMSNorm#6(dim) -> Linear#7(dim, (dim * 4))
+    Linear#7(dim, (dim * 4)) -> SiLU#8()
+    SiLU#8() -> Linear#9((dim * 4), dim)
+    Linear#9((dim * 4), dim) -> processed
+    (processed, skip) -> Add#10()
+    Add#10() -> out
 
 neuron LayerNorm(dim):
   inputs:
@@ -114,13 +113,12 @@ neuron PostNormBlock(dim):
   outputs:
     default: [*, seq, dim]
   graph:
-    in -> Fork#4()
-    Fork#4() -> (main, skip)
-    main -> Linear#5(dim, dim)
-    Linear#5(dim, dim) -> processed
-    (processed, skip) -> Add#6()
-    Add#6() -> LayerNorm#7(dim)
-    LayerNorm#7(dim) -> out
+    in -> (main, skip)
+    main -> Linear#3(dim, dim)
+    Linear#3(dim, dim) -> processed
+    (processed, skip) -> Add#4()
+    Add#4() -> LayerNorm#5(dim)
+    LayerNorm#5(dim) -> out
 
 neuron PreNormBlock(dim):
   inputs:
@@ -128,13 +126,12 @@ neuron PreNormBlock(dim):
   outputs:
     default: [*, seq, dim]
   graph:
-    in -> Fork#0()
-    Fork#0() -> (main, skip)
-    main -> LayerNorm#1(dim)
-    LayerNorm#1(dim) -> Linear#2(dim, dim)
-    Linear#2(dim, dim) -> processed
-    (processed, skip) -> Add#3()
-    Add#3() -> out
+    in -> (main, skip)
+    main -> LayerNorm#0(dim)
+    LayerNorm#0(dim) -> Linear#1(dim, dim)
+    Linear#1(dim, dim) -> processed
+    (processed, skip) -> Add#2()
+    Add#2() -> out
 
 neuron RMSNorm(dim):
   inputs:

--- a/tests/snapshots/integration_tests__example_primitives_operations.snap
+++ b/tests/snapshots/integration_tests__example_primitives_operations.snap
@@ -20,8 +20,8 @@ neuron AttentionScore(dim):
   outputs:
     default: [batch, seq, seq]
   graph:
-    (query, key) -> MatMul#9()
-    MatMul#9() -> out
+    (query, key) -> MatMul#7()
+    MatMul#7() -> out
 
 neuron Bias(dim):
   inputs:
@@ -37,17 +37,16 @@ neuron ComplexOperation(dim):
   outputs:
     default: [*, dim]
   graph:
-    in -> Fork#16()
-    Fork#16() -> (path1, path2)
-    path1 -> Linear#17(dim, dim)
-    Linear#17(dim, dim) -> Bias#18(dim)
-    Bias#18(dim) -> Scale#19(dim)
-    Scale#19(dim) -> p1_out
-    path2 -> Scale#20(dim)
-    Scale#20(dim) -> p2_out
-    (p1_out, p2_out) -> Multiply#21()
-    Multiply#21() -> Add#22()
-    Add#22() -> out
+    in -> (path1, path2)
+    path1 -> Linear#13(dim, dim)
+    Linear#13(dim, dim) -> Bias#14(dim)
+    Bias#14(dim) -> Scale#15(dim)
+    Scale#15(dim) -> p1_out
+    path2 -> Scale#16(dim)
+    Scale#16(dim) -> p2_out
+    (p1_out, p2_out) -> Multiply#17()
+    Multiply#17() -> Add#18()
+    Add#18() -> out
 
 neuron Einsum(equation):
   inputs:
@@ -73,16 +72,15 @@ neuron GatedUnit(dim, hidden_dim):
   outputs:
     default: [*, dim]
   graph:
-    in -> Fork#3()
-    Fork#3() -> (gate_path, value_path)
-    gate_path -> Linear#4(dim, hidden_dim)
-    Linear#4(dim, hidden_dim) -> SiLU#5()
-    SiLU#5() -> gate
-    value_path -> Linear#6(dim, hidden_dim)
-    Linear#6(dim, hidden_dim) -> value
-    (gate, value) -> Multiply#7()
-    Multiply#7() -> Linear#8(hidden_dim, dim)
-    Linear#8(hidden_dim, dim) -> out
+    in -> (gate_path, value_path)
+    gate_path -> Linear#2(dim, hidden_dim)
+    Linear#2(dim, hidden_dim) -> SiLU#3()
+    SiLU#3() -> gate
+    value_path -> Linear#4(dim, hidden_dim)
+    Linear#4(dim, hidden_dim) -> value
+    (gate, value) -> Multiply#5()
+    Multiply#5() -> Linear#6(hidden_dim, dim)
+    Linear#6(hidden_dim, dim) -> out
 
 neuron Linear(in_dim, out_dim):
   inputs:
@@ -98,9 +96,9 @@ neuron LinearWithBias(in_dim, out_dim):
   outputs:
     default: [*, out_dim]
   graph:
-    in -> Linear#10(in_dim, out_dim)
-    Linear#10(in_dim, out_dim) -> Bias#11(out_dim)
-    Bias#11(out_dim) -> out
+    in -> Linear#8(in_dim, out_dim)
+    Linear#8(in_dim, out_dim) -> Bias#9(out_dim)
+    Bias#9(out_dim) -> out
 
 neuron MatMul:
   inputs:
@@ -126,12 +124,11 @@ neuron ResidualAdd(dim):
   outputs:
     default: [*, dim]
   graph:
-    in -> Fork#0()
-    Fork#0() -> (main, skip)
-    main -> Linear#1(dim, dim)
-    Linear#1(dim, dim) -> processed
-    (processed, skip) -> Add#2()
-    Add#2() -> out
+    in -> (main, skip)
+    main -> Linear#0(dim, dim)
+    Linear#0(dim, dim) -> processed
+    (processed, skip) -> Add#1()
+    Add#1() -> out
 
 neuron Scale(dim):
   inputs:
@@ -155,11 +152,10 @@ neuron WeightedResidual(dim):
   outputs:
     default: [*, dim]
   graph:
-    in -> Fork#12()
-    Fork#12() -> (main, skip)
-    main -> Linear#13(dim, dim)
-    Linear#13(dim, dim) -> processed
-    processed -> Scale#14(dim)
-    Scale#14(dim) -> scaled
-    (scaled, skip) -> Add#15()
-    Add#15() -> out
+    in -> (main, skip)
+    main -> Linear#10(dim, dim)
+    Linear#10(dim, dim) -> processed
+    processed -> Scale#11(dim)
+    Scale#11(dim) -> scaled
+    (scaled, skip) -> Add#12()
+    Add#12() -> out

--- a/tests/snapshots/integration_tests__example_primitives_structural.snap
+++ b/tests/snapshots/integration_tests__example_primitives_structural.snap
@@ -19,9 +19,9 @@ neuron ClassificationHead(feature_dim, num_classes):
   outputs:
     default: [batch, num_classes]
   graph:
-    in -> Flatten#8()
-    Flatten#8() -> Linear#9(((h * w) * feature_dim), num_classes)
-    Linear#9(((h * w) * feature_dim), num_classes) -> out
+    in -> Flatten#6()
+    Flatten#6() -> Linear#7(((h * w) * feature_dim), num_classes)
+    Linear#7(((h * w) * feature_dim), num_classes) -> out
 
 neuron Concat:
   inputs:
@@ -39,8 +39,8 @@ neuron ConditionalProcessor:
     default: [*, dim]
   graph:
     in -> match:
-      [*, d] where (d > 512): Linear#10(d, 512) -> out
-      [*, d]: Identity#11() -> out
+      [*, d] where (d > 512): Linear#8(d, 512) -> out
+      [*, d]: Identity#9() -> out
 
 neuron Flatten:
   inputs:
@@ -107,12 +107,11 @@ neuron ResidualBlock(dim):
   outputs:
     default: [*, dim]
   graph:
-    in -> Fork#0()
-    Fork#0() -> (main, skip)
-    main -> Linear#1(dim, dim)
-    Linear#1(dim, dim) -> processed
-    (processed, skip) -> Add#2()
-    Add#2() -> out
+    in -> (main, skip)
+    main -> Linear#0(dim, dim)
+    Linear#0(dim, dim) -> processed
+    (processed, skip) -> Add#1()
+    Add#1() -> out
 
 neuron Slice(dim, start, end):
   inputs:
@@ -136,16 +135,15 @@ neuron ThreePathProcessor(dim):
   outputs:
     default: [*, (dim * 3)]
   graph:
-    in -> Fork3#3()
-    Fork3#3() -> (p1, p2, p3)
-    p1 -> Linear#4(dim, dim)
-    Linear#4(dim, dim) -> out1
-    p2 -> Linear#5(dim, dim)
-    Linear#5(dim, dim) -> out2
-    p3 -> Linear#6(dim, dim)
-    Linear#6(dim, dim) -> out3
-    (out1, out2, out3) -> Concat#7()
-    Concat#7() -> out
+    in -> (p1, p2, p3)
+    p1 -> Linear#2(dim, dim)
+    Linear#2(dim, dim) -> out1
+    p2 -> Linear#3(dim, dim)
+    Linear#3(dim, dim) -> out2
+    p3 -> Linear#4(dim, dim)
+    Linear#4(dim, dim) -> out3
+    (out1, out2, out3) -> Concat#5()
+    Concat#5() -> out
 
 neuron Transpose(dim0, dim1):
   inputs:

--- a/tests/snapshots/integration_tests__example_real_world_llama_rope.snap
+++ b/tests/snapshots/integration_tests__example_real_world_llama_rope.snap
@@ -10,20 +10,18 @@ neuron LlamaBlock(dim, num_heads, intermediate_size):
   outputs:
     default: [batch, seq, dim]
   graph:
-    in -> Fork#10()
-    Fork#10() -> (skip1, norm1)
-    norm1 -> RMSNorm#11(dim)
-    RMSNorm#11(dim) -> LlamaRotaryAttention#12(dim, num_heads)
-    LlamaRotaryAttention#12(dim, num_heads) -> attn_out
-    (skip1, attn_out) -> Add#13()
-    Add#13() -> residual1
-    residual1 -> Fork#14()
-    Fork#14() -> (skip2, norm2)
-    norm2 -> RMSNorm#15(dim)
-    RMSNorm#15(dim) -> SwiGLU#16(dim, intermediate_size)
-    SwiGLU#16(dim, intermediate_size) -> ffn_out
-    (skip2, ffn_out) -> Add#17()
-    Add#17() -> out
+    in -> (skip1, norm1)
+    norm1 -> RMSNorm#9(dim)
+    RMSNorm#9(dim) -> LlamaRotaryAttention#10(dim, num_heads)
+    LlamaRotaryAttention#10(dim, num_heads) -> attn_out
+    (skip1, attn_out) -> Add#11()
+    Add#11() -> residual1
+    residual1 -> (skip2, norm2)
+    norm2 -> RMSNorm#12(dim)
+    RMSNorm#12(dim) -> SwiGLU#13(dim, intermediate_size)
+    SwiGLU#13(dim, intermediate_size) -> ffn_out
+    (skip2, ffn_out) -> Add#14()
+    Add#14() -> out
 
 neuron LlamaRotaryAttention(dim, num_heads):
   inputs:
@@ -47,11 +45,11 @@ neuron MiniLlama(vocab_size, dim, num_heads, layers):
   outputs:
     default: [batch, seq, vocab_size]
   graph:
-    in -> Embedding#18(vocab_size, dim)
-    Embedding#18(vocab_size, dim) -> LlamaBlock#19(dim, num_heads, (dim * 4))
-    LlamaBlock#19(dim, num_heads, (dim * 4)) -> RMSNorm#20(dim)
-    RMSNorm#20(dim) -> Linear#21(dim, vocab_size)
-    Linear#21(dim, vocab_size) -> out
+    in -> Embedding#15(vocab_size, dim)
+    Embedding#15(vocab_size, dim) -> LlamaBlock#16(dim, num_heads, (dim * 4))
+    LlamaBlock#16(dim, num_heads, (dim * 4)) -> RMSNorm#17(dim)
+    RMSNorm#17(dim) -> Linear#18(dim, vocab_size)
+    Linear#18(dim, vocab_size) -> out
 
 neuron SwiGLU(dim, hidden_dim):
   inputs:
@@ -59,14 +57,13 @@ neuron SwiGLU(dim, hidden_dim):
   outputs:
     default: [batch, seq, dim]
   graph:
-    in -> Fork#4()
-    Fork#4() -> (gate_path, val_path)
-    gate_path -> Linear#5(dim, hidden_dim)
-    Linear#5(dim, hidden_dim) -> SiLU#6()
-    SiLU#6() -> gate
-    val_path -> Linear#7(dim, hidden_dim)
-    Linear#7(dim, hidden_dim) -> val
-    (gate, val) -> Multiply#8()
-    Multiply#8() -> hidden
-    hidden -> Linear#9(hidden_dim, dim)
-    Linear#9(hidden_dim, dim) -> out
+    in -> (gate_path, val_path)
+    gate_path -> Linear#4(dim, hidden_dim)
+    Linear#4(dim, hidden_dim) -> SiLU#5()
+    SiLU#5() -> gate
+    val_path -> Linear#6(dim, hidden_dim)
+    Linear#6(dim, hidden_dim) -> val
+    (gate, val) -> Multiply#7()
+    Multiply#7() -> hidden
+    hidden -> Linear#8(hidden_dim, dim)
+    Linear#8(hidden_dim, dim) -> out

--- a/tests/snapshots/integration_tests__example_real_world_resnet.snap
+++ b/tests/snapshots/integration_tests__example_real_world_resnet.snap
@@ -76,19 +76,19 @@ neuron ResNet18(num_classes):
   outputs:
     default: [*, num_classes]
   graph:
-    in -> ResNetStem#12(3, 64)
-    ResNetStem#12(3, 64) -> stem_out
-    stem_out -> ResidualBlock#13(64)
-    ResidualBlock#13(64) -> stage1
-    stage1 -> ResidualBlock#14(64)
-    ResidualBlock#14(64) -> stage2
-    stage2 -> ResidualBlock#15(64)
-    ResidualBlock#15(64) -> stage3
-    stage3 -> ResidualBlock#16(64)
-    ResidualBlock#16(64) -> stage4
-    stage4 -> GlobalAvgPool#17()
-    GlobalAvgPool#17() -> Linear#18(64, num_classes)
-    Linear#18(64, num_classes) -> out
+    in -> ResNetStem#11(3, 64)
+    ResNetStem#11(3, 64) -> stem_out
+    stem_out -> ResidualBlock#12(64)
+    ResidualBlock#12(64) -> stage1
+    stage1 -> ResidualBlock#13(64)
+    ResidualBlock#13(64) -> stage2
+    stage2 -> ResidualBlock#14(64)
+    ResidualBlock#14(64) -> stage3
+    stage3 -> ResidualBlock#15(64)
+    ResidualBlock#15(64) -> stage4
+    stage4 -> GlobalAvgPool#16()
+    GlobalAvgPool#16() -> Linear#17(64, num_classes)
+    Linear#17(64, num_classes) -> out
 
 neuron ResNetStem(in_channels, out_channels):
   inputs:
@@ -96,11 +96,11 @@ neuron ResNetStem(in_channels, out_channels):
   outputs:
     default: [*, out_channels, h_out, w_out]
   graph:
-    in -> Conv2d#8(in_channels, out_channels, kernel_size=7, stride=2, padding=3)
-    Conv2d#8(in_channels, out_channels, kernel_size=7, stride=2, padding=3) -> BatchNorm#9(out_channels)
-    BatchNorm#9(out_channels) -> ReLU#10()
-    ReLU#10() -> MaxPool#11(kernel_size=3, stride=2)
-    MaxPool#11(kernel_size=3, stride=2) -> out
+    in -> Conv2d#7(in_channels, out_channels, kernel_size=7, stride=2, padding=3)
+    Conv2d#7(in_channels, out_channels, kernel_size=7, stride=2, padding=3) -> BatchNorm#8(out_channels)
+    BatchNorm#8(out_channels) -> ReLU#9()
+    ReLU#9() -> MaxPool#10(kernel_size=3, stride=2)
+    MaxPool#10(kernel_size=3, stride=2) -> out
 
 neuron ResidualBlock(channels):
   inputs:
@@ -108,14 +108,13 @@ neuron ResidualBlock(channels):
   outputs:
     default: [*, channels, h, w]
   graph:
-    in -> Fork#0()
-    Fork#0() -> (main, skip)
-    main -> Conv2d#1(channels, channels, kernel_size=3, stride=1, padding=1)
-    Conv2d#1(channels, channels, kernel_size=3, stride=1, padding=1) -> BatchNorm#2(channels)
-    BatchNorm#2(channels) -> ReLU#3()
-    ReLU#3() -> Conv2d#4(channels, channels, kernel_size=3, stride=1, padding=1)
-    Conv2d#4(channels, channels, kernel_size=3, stride=1, padding=1) -> BatchNorm#5(channels)
-    BatchNorm#5(channels) -> processed
-    (processed, skip) -> Add#6()
-    Add#6() -> ReLU#7()
-    ReLU#7() -> out
+    in -> (main, skip)
+    main -> Conv2d#0(channels, channels, kernel_size=3, stride=1, padding=1)
+    Conv2d#0(channels, channels, kernel_size=3, stride=1, padding=1) -> BatchNorm#1(channels)
+    BatchNorm#1(channels) -> ReLU#2()
+    ReLU#2() -> Conv2d#3(channels, channels, kernel_size=3, stride=1, padding=1)
+    Conv2d#3(channels, channels, kernel_size=3, stride=1, padding=1) -> BatchNorm#4(channels)
+    BatchNorm#4(channels) -> processed
+    (processed, skip) -> Add#5()
+    Add#5() -> ReLU#6()
+    ReLU#6() -> out

--- a/tests/snapshots/integration_tests__example_real_world_vision_transformer.snap
+++ b/tests/snapshots/integration_tests__example_real_world_vision_transformer.snap
@@ -84,22 +84,20 @@ neuron ViTEncoderBlock(dim, num_heads):
   outputs:
     default: [batch, seq, dim]
   graph:
-    in -> Fork#0()
-    Fork#0() -> (attn_main, attn_skip)
-    attn_main -> LayerNorm#1(dim)
-    LayerNorm#1(dim) -> MultiHeadSelfAttention#2(dim, num_heads)
-    MultiHeadSelfAttention#2(dim, num_heads) -> attn_out
-    (attn_out, attn_skip) -> Add#3()
-    Add#3() -> attn_residual
-    attn_residual -> Fork#4()
-    Fork#4() -> (ffn_main, ffn_skip)
-    ffn_main -> LayerNorm#5(dim)
-    LayerNorm#5(dim) -> Linear#6(dim, (dim * 4))
-    Linear#6(dim, (dim * 4)) -> GELU#7()
-    GELU#7() -> Linear#8((dim * 4), dim)
-    Linear#8((dim * 4), dim) -> ffn_out
-    (ffn_out, ffn_skip) -> Add#9()
-    Add#9() -> out
+    in -> (attn_main, attn_skip)
+    attn_main -> LayerNorm#0(dim)
+    LayerNorm#0(dim) -> MultiHeadSelfAttention#1(dim, num_heads)
+    MultiHeadSelfAttention#1(dim, num_heads) -> attn_out
+    (attn_out, attn_skip) -> Add#2()
+    Add#2() -> attn_residual
+    attn_residual -> (ffn_main, ffn_skip)
+    ffn_main -> LayerNorm#3(dim)
+    LayerNorm#3(dim) -> Linear#4(dim, (dim * 4))
+    Linear#4(dim, (dim * 4)) -> GELU#5()
+    GELU#5() -> Linear#6((dim * 4), dim)
+    Linear#6((dim * 4), dim) -> ffn_out
+    (ffn_out, ffn_skip) -> Add#7()
+    Add#7() -> out
 
 neuron VisionTransformer(img_size, patch_size, num_classes, dim, depth, num_heads):
   inputs:
@@ -107,14 +105,14 @@ neuron VisionTransformer(img_size, patch_size, num_classes, dim, depth, num_head
   outputs:
     default: [batch, num_classes]
   graph:
-    in -> PatchEmbedding#10(patch_size, 3, dim)
-    PatchEmbedding#10(patch_size, 3, dim) -> patches
-    patches -> LearnedPositionalEmbedding#11(dim, max_len=256)
-    LearnedPositionalEmbedding#11(dim, max_len=256) -> positioned
-    positioned -> ViTEncoderBlock#12(dim, num_heads)
-    ViTEncoderBlock#12(dim, num_heads) -> ViTEncoderBlock#13(dim, num_heads)
-    ViTEncoderBlock#13(dim, num_heads) -> encoded
-    encoded -> LayerNorm#14(dim)
-    LayerNorm#14(dim) -> Slice#15(dim=1, start=0, end=1)
-    Slice#15(dim=1, start=0, end=1) -> Linear#16(dim, num_classes)
-    Linear#16(dim, num_classes) -> out
+    in -> PatchEmbedding#8(patch_size, 3, dim)
+    PatchEmbedding#8(patch_size, 3, dim) -> patches
+    patches -> LearnedPositionalEmbedding#9(dim, max_len=256)
+    LearnedPositionalEmbedding#9(dim, max_len=256) -> positioned
+    positioned -> ViTEncoderBlock#10(dim, num_heads)
+    ViTEncoderBlock#10(dim, num_heads) -> ViTEncoderBlock#11(dim, num_heads)
+    ViTEncoderBlock#11(dim, num_heads) -> encoded
+    encoded -> LayerNorm#12(dim)
+    LayerNorm#12(dim) -> Slice#13(dim=1, start=0, end=1)
+    Slice#13(dim=1, start=0, end=1) -> Linear#14(dim, num_classes)
+    Linear#14(dim, num_classes) -> out

--- a/tests/snapshots/integration_tests__example_stdlib_attention.snap
+++ b/tests/snapshots/integration_tests__example_stdlib_attention.snap
@@ -19,13 +19,12 @@ neuron AttentionBlock(dim, num_heads):
   outputs:
     default: [batch, seq, dim]
   graph:
-    in -> Fork#0()
-    Fork#0() -> (main, skip)
-    main -> LayerNorm#1(dim)
-    LayerNorm#1(dim) -> MultiHeadSelfAttention#2(dim, num_heads)
-    MultiHeadSelfAttention#2(dim, num_heads) -> processed
-    (processed, skip) -> Add#3()
-    Add#3() -> out
+    in -> (main, skip)
+    main -> LayerNorm#0(dim)
+    LayerNorm#0(dim) -> MultiHeadSelfAttention#1(dim, num_heads)
+    MultiHeadSelfAttention#1(dim, num_heads) -> processed
+    (processed, skip) -> Add#2()
+    Add#2() -> out
 
 neuron Fork:
   inputs:

--- a/tests/snapshots/integration_tests__example_stdlib_feedforward.snap
+++ b/tests/snapshots/integration_tests__example_stdlib_feedforward.snap
@@ -11,8 +11,8 @@ neuron AdaptiveFFN:
     default: [*shape, dim]
   graph:
     in -> match:
-      [*, *, d] where (d < 512): Linear#21(d, (d * 8)) -> GELU#22() -> Linear#23((d * 8), d) -> out
-      [*, *, d]: Linear#24(d, (d * 4)) -> GELU#25() -> Linear#26((d * 4), d) -> out
+      [*, *, d] where (d < 512): Linear#19(d, (d * 8)) -> GELU#20() -> Linear#21((d * 8), d) -> out
+      [*, *, d]: Linear#22(d, (d * 4)) -> GELU#23() -> Linear#24((d * 4), d) -> out
 
 neuron Add:
   inputs:
@@ -89,16 +89,15 @@ neuron GatedFFN(dim):
   outputs:
     default: [*shape, dim]
   graph:
-    in -> Fork#11()
-    Fork#11() -> (gate_path, value_path)
-    gate_path -> Linear#12(dim, (dim * 4))
-    Linear#12(dim, (dim * 4)) -> SiLU#13()
-    SiLU#13() -> gate
-    value_path -> Linear#14(dim, (dim * 4))
-    Linear#14(dim, (dim * 4)) -> value
-    (gate, value) -> Multiply#15()
-    Multiply#15() -> Linear#16((dim * 4), dim)
-    Linear#16((dim * 4), dim) -> out
+    in -> (gate_path, value_path)
+    gate_path -> Linear#11(dim, (dim * 4))
+    Linear#11(dim, (dim * 4)) -> SiLU#12()
+    SiLU#12() -> gate
+    value_path -> Linear#13(dim, (dim * 4))
+    Linear#13(dim, (dim * 4)) -> value
+    (gate, value) -> Multiply#14()
+    Multiply#14() -> Linear#15((dim * 4), dim)
+    Linear#15((dim * 4), dim) -> out
 
 neuron LayerNorm(dim):
   inputs:
@@ -139,10 +138,9 @@ neuron TransformerFFNBlock(dim):
   outputs:
     default: [*shape, dim]
   graph:
-    in -> Fork#17()
-    Fork#17() -> (main, skip)
-    main -> LayerNorm#18(dim)
-    LayerNorm#18(dim) -> FFN#19(dim)
-    FFN#19(dim) -> processed
-    (processed, skip) -> Add#20()
-    Add#20() -> out
+    in -> (main, skip)
+    main -> LayerNorm#16(dim)
+    LayerNorm#16(dim) -> FFN#17(dim)
+    FFN#17(dim) -> processed
+    (processed, skip) -> Add#18()
+    Add#18() -> out

--- a/tests/snapshots/integration_tests__example_stdlib_residual.snap
+++ b/tests/snapshots/integration_tests__example_stdlib_residual.snap
@@ -52,10 +52,10 @@ neuron MLP(dim):
   outputs:
     default: [*, dim]
   graph:
-    in -> Linear#23(dim, (dim * 4))
-    Linear#23(dim, (dim * 4)) -> GELU#24()
-    GELU#24() -> Linear#25((dim * 4), dim)
-    Linear#25((dim * 4), dim) -> out
+    in -> Linear#19(dim, (dim * 4))
+    Linear#19(dim, (dim * 4)) -> GELU#20()
+    GELU#20() -> Linear#21((dim * 4), dim)
+    Linear#21((dim * 4), dim) -> out
 
 neuron PostNormResidual(dim):
   inputs:
@@ -63,15 +63,14 @@ neuron PostNormResidual(dim):
   outputs:
     default: [*, dim]
   graph:
-    in -> Fork#14()
-    Fork#14() -> (main, skip)
-    main -> Linear#15(dim, (dim * 4))
-    Linear#15(dim, (dim * 4)) -> GELU#16()
-    GELU#16() -> Linear#17((dim * 4), dim)
-    Linear#17((dim * 4), dim) -> processed
-    (processed, skip) -> Add#18()
-    Add#18() -> LayerNorm#19(dim)
-    LayerNorm#19(dim) -> out
+    in -> (main, skip)
+    main -> Linear#11(dim, (dim * 4))
+    Linear#11(dim, (dim * 4)) -> GELU#12()
+    GELU#12() -> Linear#13((dim * 4), dim)
+    Linear#13((dim * 4), dim) -> processed
+    (processed, skip) -> Add#14()
+    Add#14() -> LayerNorm#15(dim)
+    LayerNorm#15(dim) -> out
 
 neuron PreNormResidual(dim):
   inputs:
@@ -79,15 +78,14 @@ neuron PreNormResidual(dim):
   outputs:
     default: [*, dim]
   graph:
-    in -> Fork#8()
-    Fork#8() -> (main, skip)
-    main -> LayerNorm#9(dim)
-    LayerNorm#9(dim) -> Linear#10(dim, (dim * 4))
-    Linear#10(dim, (dim * 4)) -> GELU#11()
-    GELU#11() -> Linear#12((dim * 4), dim)
-    Linear#12((dim * 4), dim) -> processed
-    (processed, skip) -> Add#13()
-    Add#13() -> out
+    in -> (main, skip)
+    main -> LayerNorm#6(dim)
+    LayerNorm#6(dim) -> Linear#7(dim, (dim * 4))
+    Linear#7(dim, (dim * 4)) -> GELU#8()
+    GELU#8() -> Linear#9((dim * 4), dim)
+    Linear#9((dim * 4), dim) -> processed
+    (processed, skip) -> Add#10()
+    Add#10() -> out
 
 neuron Residual(dim):
   inputs:
@@ -95,14 +93,13 @@ neuron Residual(dim):
   outputs:
     default: [*, dim]
   graph:
-    in -> Fork#0()
-    Fork#0() -> (main, skip)
-    main -> Linear#1(dim, (dim * 4))
-    Linear#1(dim, (dim * 4)) -> GELU#2()
-    GELU#2() -> Linear#3((dim * 4), dim)
-    Linear#3((dim * 4), dim) -> processed
-    (processed, skip) -> Add#4()
-    Add#4() -> out
+    in -> (main, skip)
+    main -> Linear#0(dim, (dim * 4))
+    Linear#0(dim, (dim * 4)) -> GELU#1()
+    GELU#1() -> Linear#2((dim * 4), dim)
+    Linear#2((dim * 4), dim) -> processed
+    (processed, skip) -> Add#3()
+    Add#3() -> out
 
 neuron ResidualMLP(dim):
   inputs:
@@ -110,12 +107,11 @@ neuron ResidualMLP(dim):
   outputs:
     default: [*, dim]
   graph:
-    in -> Fork#5()
-    Fork#5() -> (main, skip)
-    main -> MLP#6(dim)
-    MLP#6(dim) -> processed
-    (processed, skip) -> Add#7()
-    Add#7() -> out
+    in -> (main, skip)
+    main -> MLP#4(dim)
+    MLP#4(dim) -> processed
+    (processed, skip) -> Add#5()
+    Add#5() -> out
 
 neuron StackedResiduals(dim, depth):
   inputs:
@@ -123,7 +119,7 @@ neuron StackedResiduals(dim, depth):
   outputs:
     default: [*, dim]
   graph:
-    in -> Residual#20(dim)
-    Residual#20(dim) -> Residual#21(dim)
-    Residual#21(dim) -> Residual#22(dim)
-    Residual#22(dim) -> out
+    in -> Residual#16(dim)
+    Residual#16(dim) -> Residual#17(dim)
+    Residual#17(dim) -> Residual#18(dim)
+    Residual#18(dim) -> out

--- a/tests/snapshots/integration_tests__example_stdlib_transformer_block.snap
+++ b/tests/snapshots/integration_tests__example_stdlib_transformer_block.snap
@@ -19,10 +19,10 @@ neuron FFN(dim):
   outputs:
     default: [*shape, dim]
   graph:
-    in -> Linear#8(dim, (dim * 4))
-    Linear#8(dim, (dim * 4)) -> GELU#9()
-    GELU#9() -> Linear#10((dim * 4), dim)
-    Linear#10((dim * 4), dim) -> out
+    in -> Linear#6(dim, (dim * 4))
+    Linear#6(dim, (dim * 4)) -> GELU#7()
+    GELU#7() -> Linear#8((dim * 4), dim)
+    Linear#8((dim * 4), dim) -> out
 
 neuron Fork:
   inputs:
@@ -71,17 +71,15 @@ neuron TransformerBlock(dim, num_heads):
   outputs:
     default: [batch, seq, dim]
   graph:
-    in -> Fork#0()
-    Fork#0() -> (attn_main, attn_skip)
-    attn_main -> LayerNorm#1(dim)
-    LayerNorm#1(dim) -> MultiHeadSelfAttention#2(dim, num_heads)
-    MultiHeadSelfAttention#2(dim, num_heads) -> attn_out
-    (attn_out, attn_skip) -> Add#3()
-    Add#3() -> attn_residual
-    attn_residual -> Fork#4()
-    Fork#4() -> (ffn_main, ffn_skip)
-    ffn_main -> LayerNorm#5(dim)
-    LayerNorm#5(dim) -> FFN#6(dim)
-    FFN#6(dim) -> ffn_out
-    (ffn_out, ffn_skip) -> Add#7()
-    Add#7() -> out
+    in -> (attn_main, attn_skip)
+    attn_main -> LayerNorm#0(dim)
+    LayerNorm#0(dim) -> MultiHeadSelfAttention#1(dim, num_heads)
+    MultiHeadSelfAttention#1(dim, num_heads) -> attn_out
+    (attn_out, attn_skip) -> Add#2()
+    Add#2() -> attn_residual
+    attn_residual -> (ffn_main, ffn_skip)
+    ffn_main -> LayerNorm#3(dim)
+    LayerNorm#3(dim) -> FFN#4(dim)
+    FFN#4(dim) -> ffn_out
+    (ffn_out, ffn_skip) -> Add#5()
+    Add#5() -> out

--- a/tests/snapshots/integration_tests__example_stdlib_transformer_stack.snap
+++ b/tests/snapshots/integration_tests__example_stdlib_transformer_stack.snap
@@ -60,22 +60,20 @@ neuron TransformerBlock(dim, num_heads):
   outputs:
     default: [batch, seq, dim]
   graph:
-    in -> Fork#3()
-    Fork#3() -> (attn_main, attn_skip)
-    attn_main -> LayerNorm#4(dim)
-    LayerNorm#4(dim) -> MultiHeadSelfAttention#5(dim, num_heads)
-    MultiHeadSelfAttention#5(dim, num_heads) -> attn_out
-    (attn_out, attn_skip) -> Add#6()
-    Add#6() -> attn_residual
-    attn_residual -> Fork#7()
-    Fork#7() -> (ffn_main, ffn_skip)
-    ffn_main -> LayerNorm#8(dim)
-    LayerNorm#8(dim) -> Linear#9(dim, (dim * 4))
-    Linear#9(dim, (dim * 4)) -> GELU#10()
-    GELU#10() -> Linear#11((dim * 4), dim)
-    Linear#11((dim * 4), dim) -> ffn_out
-    (ffn_out, ffn_skip) -> Add#12()
-    Add#12() -> out
+    in -> (attn_main, attn_skip)
+    attn_main -> LayerNorm#3(dim)
+    LayerNorm#3(dim) -> MultiHeadSelfAttention#4(dim, num_heads)
+    MultiHeadSelfAttention#4(dim, num_heads) -> attn_out
+    (attn_out, attn_skip) -> Add#5()
+    Add#5() -> attn_residual
+    attn_residual -> (ffn_main, ffn_skip)
+    ffn_main -> LayerNorm#6(dim)
+    LayerNorm#6(dim) -> Linear#7(dim, (dim * 4))
+    Linear#7(dim, (dim * 4)) -> GELU#8()
+    GELU#8() -> Linear#9((dim * 4), dim)
+    Linear#9((dim * 4), dim) -> ffn_out
+    (ffn_out, ffn_skip) -> Add#10()
+    Add#10() -> out
 
 neuron TransformerStack(dim, num_heads, num_layers):
   inputs:

--- a/tests/snapshots/integration_tests__example_tutorials_02_fork_join.snap
+++ b/tests/snapshots/integration_tests__example_tutorials_02_fork_join.snap
@@ -72,16 +72,14 @@ neuron NestedResidual(dim):
   outputs:
     default: [*, dim]
   graph:
-    in -> Fork#12()
-    Fork#12() -> (outer_main, outer_skip)
-    outer_main -> Fork#13()
-    Fork#13() -> (inner_main, inner_skip)
-    inner_main -> Linear#14(dim, dim)
-    Linear#14(dim, dim) -> inner_processed
-    (inner_processed, inner_skip) -> Add#15()
-    Add#15() -> inner_sum
-    (inner_sum, outer_skip) -> Add#16()
-    Add#16() -> out
+    in -> (outer_main, outer_skip)
+    outer_main -> (inner_main, inner_skip)
+    inner_main -> Linear#9(dim, dim)
+    Linear#9(dim, dim) -> inner_processed
+    (inner_processed, inner_skip) -> Add#10()
+    Add#10() -> inner_sum
+    (inner_sum, outer_skip) -> Add#11()
+    Add#11() -> out
 
 neuron ParallelProcessing(dim):
   inputs:
@@ -89,16 +87,15 @@ neuron ParallelProcessing(dim):
   outputs:
     default: [*, (dim * 3)]
   graph:
-    in -> Fork3#7()
-    Fork3#7() -> (path1, path2, path3)
-    path1 -> Linear#8(dim, dim)
-    Linear#8(dim, dim) -> p1
-    path2 -> Linear#9(dim, dim)
-    Linear#9(dim, dim) -> p2
-    path3 -> Linear#10(dim, dim)
-    Linear#10(dim, dim) -> p3
-    (p1, p2, p3) -> Concat#11()
-    Concat#11() -> out
+    in -> (path1, path2, path3)
+    path1 -> Linear#5(dim, dim)
+    Linear#5(dim, dim) -> p1
+    path2 -> Linear#6(dim, dim)
+    Linear#6(dim, dim) -> p2
+    path3 -> Linear#7(dim, dim)
+    Linear#7(dim, dim) -> p3
+    (p1, p2, p3) -> Concat#8()
+    Concat#8() -> out
 
 neuron PreActivationResidual(dim):
   inputs:
@@ -106,15 +103,14 @@ neuron PreActivationResidual(dim):
   outputs:
     default: [batch, dim]
   graph:
-    in -> Fork#17()
-    Fork#17() -> (main, skip)
-    main -> LayerNorm#18(dim)
-    LayerNorm#18(dim) -> Linear#19(dim, (dim * 4))
-    Linear#19(dim, (dim * 4)) -> GELU#20()
-    GELU#20() -> Linear#21((dim * 4), dim)
-    Linear#21((dim * 4), dim) -> processed
-    (processed, skip) -> Add#22()
-    Add#22() -> out
+    in -> (main, skip)
+    main -> LayerNorm#12(dim)
+    LayerNorm#12(dim) -> Linear#13(dim, (dim * 4))
+    Linear#13(dim, (dim * 4)) -> GELU#14()
+    GELU#14() -> Linear#15((dim * 4), dim)
+    Linear#15((dim * 4), dim) -> processed
+    (processed, skip) -> Add#16()
+    Add#16() -> out
 
 neuron ResidualBlock(dim):
   inputs:
@@ -122,14 +118,13 @@ neuron ResidualBlock(dim):
   outputs:
     default: [*, dim]
   graph:
-    in -> Fork#2()
-    Fork#2() -> (main, skip)
-    main -> Linear#3(dim, (dim * 4))
-    Linear#3(dim, (dim * 4)) -> GELU#4()
-    GELU#4() -> Linear#5((dim * 4), dim)
-    Linear#5((dim * 4), dim) -> processed
-    (processed, skip) -> Add#6()
-    Add#6() -> out
+    in -> (main, skip)
+    main -> Linear#1(dim, (dim * 4))
+    Linear#1(dim, (dim * 4)) -> GELU#2()
+    GELU#2() -> Linear#3((dim * 4), dim)
+    Linear#3((dim * 4), dim) -> processed
+    (processed, skip) -> Add#4()
+    Add#4() -> out
 
 neuron SimpleFork:
   inputs:
@@ -156,7 +151,6 @@ neuron UnpackExample(dim):
   outputs:
     default: [*, dim]
   graph:
-    in -> Fork#0()
-    Fork#0() -> (main, skip)
-    main -> Linear#1(dim, dim)
-    Linear#1(dim, dim) -> out
+    in -> (main, skip)
+    main -> Linear#0(dim, dim)
+    Linear#0(dim, dim) -> out

--- a/tests/snapshots/integration_tests__parser_ir_residual.snap
+++ b/tests/snapshots/integration_tests__parser_ir_residual.snap
@@ -58,9 +58,8 @@ neuron Residual(dim):
   outputs:
     default: [*, dim]
   graph:
-    in -> Fork#3()
-    Fork#3() -> (main, skip)
-    main -> MLP#4(dim)
-    MLP#4(dim) -> processed
-    (processed, skip) -> Add#5()
-    Add#5() -> out
+    in -> (main, skip)
+    main -> MLP#3(dim)
+    MLP#3(dim) -> processed
+    (processed, skip) -> Add#4()
+    Add#4() -> out

--- a/tests/snapshots/integration_tests__stdlib_TransformerBlock.snap
+++ b/tests/snapshots/integration_tests__stdlib_TransformerBlock.snap
@@ -21,19 +21,17 @@ neuron TransformerBlock(dim, num_heads, d_ff):
   outputs:
     default: [batch, seq, dim]
   graph:
-    in -> Fork#3()
-    Fork#3() -> (skip1, attn_path)
-    attn_path -> LayerNorm#4(dim)
-    LayerNorm#4(dim) -> MultiHeadSelfAttention#5(dim, num_heads)
-    MultiHeadSelfAttention#5(dim, num_heads) -> Dropout#6(0.1)
-    Dropout#6(0.1) -> attn_out
-    (skip1, attn_out) -> Add#7()
-    Add#7() -> attn_residual
-    attn_residual -> Fork#8()
-    Fork#8() -> (skip2, ffn_path)
-    ffn_path -> LayerNorm#9(dim)
-    LayerNorm#9(dim) -> FFN#10(dim, d_ff)
-    FFN#10(dim, d_ff) -> Dropout#11(0.1)
-    Dropout#11(0.1) -> ffn_out
-    (skip2, ffn_out) -> Add#12()
-    Add#12() -> out
+    in -> (skip1, attn_path)
+    attn_path -> LayerNorm#3(dim)
+    LayerNorm#3(dim) -> MultiHeadSelfAttention#4(dim, num_heads)
+    MultiHeadSelfAttention#4(dim, num_heads) -> Dropout#5(0.1)
+    Dropout#5(0.1) -> attn_out
+    (skip1, attn_out) -> Add#6()
+    Add#6() -> attn_residual
+    attn_residual -> (skip2, ffn_path)
+    ffn_path -> LayerNorm#7(dim)
+    LayerNorm#7(dim) -> FFN#8(dim, d_ff)
+    FFN#8(dim, d_ff) -> Dropout#9(0.1)
+    Dropout#9(0.1) -> ffn_out
+    (skip2, ffn_out) -> Add#10()
+    Add#10() -> out


### PR DESCRIPTION
## Summary
- Replace all explicit `Fork() ->` and `Fork3() ->` patterns with implicit fork syntax (`in -> (a, b, c)`) across 18 `.ns` files in stdlib and examples
- Update CLAUDE.md to document implicit fork as the preferred splitting method
- Update 17 integration test snapshots to match new syntax

## Details

v0.3.0 introduced implicit fork — any single-output source can flow directly into an N-element tuple without an explicit Fork/Fork3 call. This PR migrates all existing code to use the new syntax consistently.

**Files changed:**
- `CLAUDE.md` — 3 sections updated (constraints, connections, tuple unpacking)
- `stdlib/` — TransformerBlock.ns, MetaNeurons.ns, Residual.ns
- `examples/` — 15 files across primitives, stdlib, tutorials, and real-world
- `tests/snapshots/` — 17 snapshot files updated

**Not changed:**
- `examples/DilatedConv.ns` — Fork3() used in multi-line pipeline (different pattern)
- `examples/variable_length_tuple.ns` — already uses implicit fork
- Primitive definitions (neuron Fork/Fork3 with impl:) — still valid primitives
- `.claude/skills/` — updated locally but gitignored

## Test plan
- [x] `cargo build --release` passes
- [x] `cargo test` passes (all 13 integration tests + unit tests)
- [x] All modified `.ns` files validate with `neuroscript validate`
- [x] Snapshots reviewed and accepted via `cargo insta accept`

🤖 Generated with [Claude Code](https://claude.com/claude-code)