### PR TITLE
fix: allow blank lines between doc comments and neuron keyword

### DIFF
--- a/examples/doc_comment_blank_line.ns
+++ b/examples/doc_comment_blank_line.ns
@@ -1,0 +1,27 @@
+use core,nn/*
+
+/// A simple neuron with a blank line before the keyword
+///
+/// This tests that blank lines between doc comments and neuron are allowed
+
+neuron DocBlankLine(dim):
+  in: [*, dim]
+  out: [*, dim]
+  graph:
+    in -> Linear(dim, dim) -> out
+
+/// Another neuron with multiple blank lines
+
+
+neuron DocMultipleBlankLines(dim):
+  in: [*, dim]
+  out: [*, dim]
+  graph:
+    in -> Linear(dim, dim) -> out
+
+/// A neuron with no blank line (should still work)
+neuron DocNoBlankLine(dim):
+  in: [*, dim]
+  out: [*, dim]
+  graph:
+    in -> Linear(dim, dim) -> out

--- a/src/grammar/ast.rs
+++ b/src/grammar/ast.rs
@@ -161,7 +161,16 @@ impl AstBuilder {
         if let Some(ref p) = next {
             if p.as_rule() == Rule::doc_block {
                 doc = Some(self.build_doc_block(p.clone())?);
-                next = inner.next(); // Move to keyword_neuron
+                next = inner.next();
+            }
+        }
+
+        // Skip any blank lines (NEWLINEs) between doc_block and keyword_neuron
+        while let Some(ref p) = next {
+            if p.as_rule() == Rule::NEWLINE {
+                next = inner.next();
+            } else {
+                break;
             }
         }
 

--- a/src/grammar/neuroscript.pest
+++ b/src/grammar/neuroscript.pest
@@ -407,8 +407,9 @@ neuron_section = {
 
 // Neuron definition: neuron Foo(params): ...
 // Optionally preceded by documentation comments
+// Blank lines between doc_block and keyword_neuron are allowed
 neuron_def = {
-    doc_block? ~ keyword_neuron ~ ident ~ params? ~ colon ~ NEWLINE ~
+    doc_block? ~ NEWLINE* ~ keyword_neuron ~ ident ~ params? ~ colon ~ NEWLINE ~
     (NEWLINE* ~ neuron_section)+
 }
 

--- a/src/grammar/tests.rs
+++ b/src/grammar/tests.rs
@@ -211,3 +211,35 @@ fn test_parse_simple_neuron_with_if() {
     }
     assert!(result.is_ok());
 }
+
+#[test]
+fn test_doc_comment_blank_line_before_neuron() {
+    // Single blank line between doc comment and neuron keyword
+    let input = r#"/// A documented neuron
+
+neuron Test:
+  in: [*, dim]
+  out: [*, dim]
+  impl: core,nn/Linear
+"#;
+    let result = NeuroScriptParser::parse(Rule::neuron_def, input);
+    if let Err(e) = &result {
+        eprintln!("Error: {}", e);
+    }
+    assert!(result.is_ok(), "Failed to parse neuron_def with single blank line after doc comment");
+
+    // Multiple blank lines between doc comment and neuron keyword
+    let input_multi = r#"/// A documented neuron
+
+
+neuron Test:
+  in: [*, dim]
+  out: [*, dim]
+  impl: core,nn/Linear
+"#;
+    let result_multi = NeuroScriptParser::parse(Rule::neuron_def, input_multi);
+    if let Err(e) = &result_multi {
+        eprintln!("Error: {}", e);
+    }
+    assert!(result_multi.is_ok(), "Failed to parse neuron_def with multiple blank lines after doc comment");
+}

--- a/tests/snapshots/integration_tests__example_doc_comment_blank_line.snap
+++ b/tests/snapshots/integration_tests__example_doc_comment_blank_line.snap
@@ -1,0 +1,35 @@
+---
+source: tests/integration_tests.rs
+expression: formatted
+---
+=== Uses ===
+use nn::* (source: core)
+
+=== Neurons ===
+
+neuron DocBlankLine(dim):
+  inputs:
+    default: [*, dim]
+  outputs:
+    default: [*, dim]
+  graph:
+    in -> Linear#0(dim, dim)
+    Linear#0(dim, dim) -> out
+
+neuron DocMultipleBlankLines(dim):
+  inputs:
+    default: [*, dim]
+  outputs:
+    default: [*, dim]
+  graph:
+    in -> Linear#1(dim, dim)
+    Linear#1(dim, dim) -> out
+
+neuron DocNoBlankLine(dim):
+  inputs:
+    default: [*, dim]
+  outputs:
+    default: [*, dim]
+  graph:
+    in -> Linear#2(dim, dim)
+    Linear#2(dim, dim) -> out


### PR DESCRIPTION
## Summary
- Adjusted the PEG grammar (`neuroscript.pest`) to allow optional blank lines (`NEWLINE*`) between `doc_block` and `keyword_neuron` in `neuron_def`
- Updated the AST builder (`ast.rs`) to skip NEWLINE pairs that appear between the doc block and keyword
- Added a grammar unit test and an example `.ns` file covering single and multiple blank lines

## Context
A blank line between a `///` doc comment block and the `neuron` keyword caused a parse error. The grammar rule `doc_block = { (DOC_COMMENT ~ NEWLINE)+ }` treated the blank line as terminating the doc block, then failed to find `neuron` immediately after. Both the GeGLU and GatedFFN agents hit this and had to manually remove the blank line as a workaround.

## Test plan
- [x] New unit test `test_doc_comment_blank_line_before_neuron` covers single and multiple blank lines
- [x] New example file `examples/doc_comment_blank_line.ns` parses and validates correctly
- [x] All 181 unit tests pass
- [x] All 13 integration/snapshot tests pass
- [x] No-blank-line case (existing behavior) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)