### PR TITLE
feat: stdlib neuron cross-references and composition

### DIFF
--- a/.claude/skills/ns-create/SKILL.md
+++ b/.claude/skills/ns-create/SKILL.md
@@ -31,6 +31,8 @@ Before creating, verify the neuron doesn't already exist:
 - Check `stdlib/*.ns` for composite library neurons
 - Check `examples/` for similar patterns
 
+**Reuse stdlib composites**: If the neuron you're building contains a sub-pattern that already exists in `stdlib/`, reference it by name instead of inlining the logic. All stdlib neurons (primitives and composites) are automatically loaded and available by name in any `.ns` file. For example, use `SEBlock(channels, reduction)` instead of inlining the squeeze-and-excitation pattern. See `examples/stdlib_composition.ns` for examples of composing stdlib neurons.
+
 ### 3. Choose Pattern
 
 | Pattern | When to Use | Template |

--- a/.claude/skills/ns-create/references/common-pitfalls.md
+++ b/.claude/skills/ns-create/references/common-pitfalls.md
@@ -146,3 +146,27 @@ When using tuple unpacking (implicit or explicit), the names you assign override
 in -> (processed, residual)            # implicit fork — your names
 (processed, residual) -> Add() -> out  # matched by position, not name
 ```
+
+## 11. Inlining Instead of Reusing Stdlib
+
+**Wrong**: Duplicating a pattern that already exists in stdlib
+```neuroscript
+# Inlining the SE pattern manually
+se_input -> (features, attn_path)
+attn_path ->
+    GlobalAvgPool()
+    Flatten()
+    Linear(channels, channels / reduction)
+    ReLU()
+    Linear(channels / reduction, channels)
+    Sigmoid()
+    attention
+(features, attention) -> Multiply() -> se_out
+```
+
+**Right**: Reference the stdlib neuron by name
+```neuroscript
+se_input -> SEBlock(channels, reduction) -> se_out
+```
+
+All stdlib neurons (primitives and composites) are loaded automatically. Check `stdlib/*.ns` before inlining a sub-pattern.

--- a/examples/stdlib_composition.ns
+++ b/examples/stdlib_composition.ns
@@ -1,0 +1,31 @@
+# Example: Composing stdlib neurons
+#
+# Demonstrates reusing stdlib composite neurons (FFN, SEBlock,
+# TransformerBlock, MBConvBlock) instead of inlining their patterns.
+# All stdlib neurons are available by name — no `use` statement needed.
+
+/// Pre-norm residual FFN block
+/// Composes stdlib's FFN inside a residual connection with layer normalization.
+neuron PreNormFFNBlock(dim, d_ff):
+    in: [*batch, seq, dim]
+    out: [*batch, seq, dim]
+    graph:
+        in -> (main, skip)
+        main ->
+            LayerNorm(dim)
+            FFN(dim, d_ff)
+            Dropout(0.1)
+            processed
+        (processed, skip) -> Add() -> out
+
+/// EfficientNet-style convolution stage
+/// Composes MBConvBlock (which itself uses SEBlock) three times.
+neuron EfficientStage(channels, expansion, reduction):
+    in: [batch, channels, height, width]
+    out: [batch, channels, height, width]
+    graph:
+        in ->
+            MBConvBlock(channels, expansion, reduction)
+            MBConvBlock(channels, expansion, reduction)
+            MBConvBlock(channels, expansion, reduction)
+            out

--- a/notes/language-gaps.md
+++ b/notes/language-gaps.md
@@ -67,14 +67,8 @@ The word `context` cannot be used as a port name or identifier because it's rese
 
 **Neurons affected**: CrossAttention (worked around by using `memory`).
 
-## 6. Inter-neuron stdlib references need `use` statements
+## ~~6. Inter-neuron stdlib references need `use` statements~~ (RESOLVED)
 
-**Impact**: Low | **Difficulty**: Already implemented
+**Impact**: Low | **Difficulty**: Already implemented | **Status**: Done
 
-This turned out to not be a limitation — `use` statements work. However, none of the generated neurons currently use `use` statements to reference other stdlib neurons. MBConvBlock inlined the SE pattern instead of importing SEBlock.
-
-**What needs to change**:
-
-- No language change needed
-- Update the ns-create skill to recommend `use stdlib, SEBlock/*` when a dependency exists in stdlib
-- Verify that `use` + compilation works end-to-end for stdlib-to-stdlib references
+Stdlib neurons can reference other stdlib neurons directly by name — all `.ns` files in `stdlib/` are loaded and merged automatically. No `use` statement is needed for stdlib-to-stdlib references. MBConvBlock has been refactored to use `SEBlock(channels * expansion, reduction)` instead of inlining the SE pattern. The ns-create skill now recommends reusing stdlib composites. See `examples/stdlib_composition.ns` for a demonstration of composing stdlib neurons (PreNormFFNBlock uses FFN; EfficientStage uses MBConvBlock which uses SEBlock).

--- a/stdlib/MBConvBlock.ns
+++ b/stdlib/MBConvBlock.ns
@@ -1,5 +1,6 @@
 /// Mobile Inverted Bottleneck Block (MBConv)
 /// Used in EfficientNet. Expand -> Depthwise -> SE -> Project with residual.
+/// Uses SEBlock for channel attention instead of inlining the SE pattern.
 /// Reference: Tan & Le (2019), "EfficientNet"
 neuron MBConvBlock(channels, expansion, reduction):
     in: [batch, channels, height, width]
@@ -13,18 +14,7 @@ neuron MBConvBlock(channels, expansion, reduction):
             DepthwiseConv(channels * expansion, channels * expansion, 3, 1, 1)
             BatchNorm(channels * expansion)
             SiLU()
-            se_input
-        se_input -> (features, attn_path)
-        attn_path ->
-            GlobalAvgPool()
-            Flatten()
-            Linear(channels * expansion, channels * expansion / reduction)
-            ReLU()
-            Linear(channels * expansion / reduction, channels * expansion)
-            Sigmoid()
-            attention
-        (features, attention) -> Multiply() -> se_out
-        se_out ->
+            SEBlock(channels * expansion, reduction)
             Conv2d(channels * expansion, channels, 1, 1, 0)
             BatchNorm(channels)
             projected

--- a/tests/snapshots/integration_tests__example_stdlib_composition.snap
+++ b/tests/snapshots/integration_tests__example_stdlib_composition.snap
@@ -1,0 +1,30 @@
+---
+source: tests/integration_tests.rs
+expression: formatted
+---
+=== Neurons ===
+
+neuron EfficientStage(channels, expansion, reduction):
+  inputs:
+    default: [batch, channels, height, width]
+  outputs:
+    default: [batch, channels, height, width]
+  graph:
+    in -> MBConvBlock#4(channels, expansion, reduction)
+    MBConvBlock#4(channels, expansion, reduction) -> MBConvBlock#5(channels, expansion, reduction)
+    MBConvBlock#5(channels, expansion, reduction) -> MBConvBlock#6(channels, expansion, reduction)
+    MBConvBlock#6(channels, expansion, reduction) -> out
+
+neuron PreNormFFNBlock(dim, d_ff):
+  inputs:
+    default: [*batch, seq, dim]
+  outputs:
+    default: [*batch, seq, dim]
+  graph:
+    in -> (main, skip)
+    main -> LayerNorm#0(dim)
+    LayerNorm#0(dim) -> FFN#1(dim, d_ff)
+    FFN#1(dim, d_ff) -> Dropout#2(0.1)
+    Dropout#2(0.1) -> processed
+    (processed, skip) -> Add#3()
+    Add#3() -> out

--- a/tests/snapshots/integration_tests__stdlib_MBConvBlock.snap
+++ b/tests/snapshots/integration_tests__stdlib_MBConvBlock.snap
@@ -17,19 +17,9 @@ neuron MBConvBlock(channels, expansion, reduction):
     SiLU#2() -> DepthwiseConv#3((channels * expansion), (channels * expansion), 3, 1, 1)
     DepthwiseConv#3((channels * expansion), (channels * expansion), 3, 1, 1) -> BatchNorm#4((channels * expansion))
     BatchNorm#4((channels * expansion)) -> SiLU#5()
-    SiLU#5() -> se_input
-    se_input -> (features, attn_path)
-    attn_path -> GlobalAvgPool#6()
-    GlobalAvgPool#6() -> Flatten#7()
-    Flatten#7() -> Linear#8((channels * expansion), ((channels * expansion) / reduction))
-    Linear#8((channels * expansion), ((channels * expansion) / reduction)) -> ReLU#9()
-    ReLU#9() -> Linear#10(((channels * expansion) / reduction), (channels * expansion))
-    Linear#10(((channels * expansion) / reduction), (channels * expansion)) -> Sigmoid#11()
-    Sigmoid#11() -> attention
-    (features, attention) -> Multiply#12()
-    Multiply#12() -> se_out
-    se_out -> Conv2d#13((channels * expansion), channels, 1, 1, 0)
-    Conv2d#13((channels * expansion), channels, 1, 1, 0) -> BatchNorm#14(channels)
-    BatchNorm#14(channels) -> projected
-    (projected, skip) -> Add#15()
-    Add#15() -> out
+    SiLU#5() -> SEBlock#6((channels * expansion), reduction)
+    SEBlock#6((channels * expansion), reduction) -> Conv2d#7((channels * expansion), channels, 1, 1, 0)
+    Conv2d#7((channels * expansion), channels, 1, 1, 0) -> BatchNorm#8(channels)
+    BatchNorm#8(channels) -> projected
+    (projected, skip) -> Add#9()
+    Add#9() -> out


### PR DESCRIPTION
## Summary
- Refactored `MBConvBlock` to use `SEBlock` directly instead of inlining the squeeze-and-excitation pattern (31 → 21 lines)
- Added `examples/stdlib_composition.ns` demonstrating stdlib composite reuse (PreNormFFNBlock uses FFN; EfficientStage chains MBConvBlock which uses SEBlock)
- Updated `ns-create` skill to recommend reusing stdlib composites instead of inlining patterns
- Added pitfall #11 to common-pitfalls reference: "Inlining Instead of Reusing Stdlib"
- Marked language-gaps task 6 (inter-neuron stdlib references) as RESOLVED

Closes language-gaps.md task 6: all stdlib neurons are available by name automatically — no `use` statement needed for stdlib-to-stdlib composition.

## Test plan
- [x] `cargo test` — all 13 integration tests pass (snapshots updated)
- [x] `neuroscript validate stdlib/MBConvBlock.ns` — valid
- [x] `neuroscript compile stdlib/MBConvBlock.ns` — generates correct nested SEBlock + MBConvBlock classes
- [x] `neuroscript compile examples/stdlib_composition.ns --neuron PreNormFFNBlock` — compiles with FFN dependency
- [x] `neuroscript compile examples/stdlib_composition.ns --neuron EfficientStage` — compiles with 3-level nesting (EfficientStage → MBConvBlock → SEBlock)

🤖 Generated with [Claude Code](https://claude.com/claude-code)