### PR TITLE
fix: address code review issues from fat arrow implementation

### DIFF
--- a/src/codegen/forward.rs
+++ b/src/codegen/forward.rs
@@ -1178,23 +1178,13 @@ fn process_destination(
                             .collect::<Result<Vec<_>, _>>()?
                             .join(", ");
 
-                        if unsqueeze_indices.is_empty() {
-                            // No new dims — just expand existing size-1 dims
-                            writeln!(
-                                output,
-                                "{}{} = {}.expand({})",
-                                indent, result_var, source_var, shape_args
-                            )
-                            .unwrap();
-                        } else {
-                            // Expand after unsqueezing
-                            writeln!(
-                                output,
-                                "{}{} = {}.expand({})",
-                                indent, result_var, current, shape_args
-                            )
-                            .unwrap();
-                        }
+                        // Expand (current == source_var when no unsqueezes were needed)
+                        writeln!(
+                            output,
+                            "{}{} = {}.expand({})",
+                            indent, result_var, current, shape_args
+                        )
+                        .unwrap();
                     }
                     TransformStrategy::Neuron { .. } => {
                         let module_name = format!("self._transform_{}", reshape.id);
@@ -1223,12 +1213,16 @@ fn process_destination(
 /// Convert a DimExpr to Python code for dimension arithmetic (uses // for division).
 /// Returns an error if the expression contains comparison operators, which are not
 /// valid in dimension arithmetic contexts.
+///
+/// Note: Div maps to `//` (integer division) here because reshape dimensions are
+/// always integers. This differs from `binop_to_str(op, false)` used in general
+/// value expressions, which emits `/` (float division). See `binop_to_str` docs.
 fn dim_expr_to_python(gen: &CodeGenerator, expr: &DimExpr) -> Result<String, CodegenError> {
     let op_str = match expr.op {
         BinOp::Add => "+",
         BinOp::Sub => "-",
         BinOp::Mul => "*",
-        BinOp::Div => "//",
+        BinOp::Div => "//", // Integer division — see doc comment above
         op => {
             return Err(CodegenError::UnsupportedFeature(format!(
                 "comparison operator {:?} is not valid in dimension expressions",

--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -960,3 +960,151 @@ neuron BroadcastTest(dim):
         "should contain expand call for copy repeat"
     );
 }
+
+#[test]
+fn test_codegen_fat_arrow_reduce_min() {
+    let source = r#"
+neuron MinPool(dim):
+  in: [batch, seq, dim]
+  out: [batch, dim]
+  graph:
+    in => @reduce(min) [batch, dim] -> out
+"#;
+    let mut program = parse(source).unwrap();
+    validate(&mut program).unwrap();
+    let result = generate_pytorch(&program, "MinPool");
+    assert!(result.is_ok(), "codegen should succeed: {:?}", result);
+    let code = result.unwrap();
+    println!("=== REDUCE MIN ===\n{}", code);
+    assert!(
+        code.contains(".amin("),
+        "should contain .amin() call (not .min() which returns (values, indices))"
+    );
+}
+
+#[test]
+fn test_codegen_fat_arrow_reduce_max() {
+    let source = r#"
+neuron MaxPool(dim):
+  in: [batch, seq, dim]
+  out: [batch, dim]
+  graph:
+    in => @reduce(max) [batch, dim] -> out
+"#;
+    let mut program = parse(source).unwrap();
+    validate(&mut program).unwrap();
+    let result = generate_pytorch(&program, "MaxPool");
+    assert!(result.is_ok(), "codegen should succeed: {:?}", result);
+    let code = result.unwrap();
+    println!("=== REDUCE MAX ===\n{}", code);
+    assert!(
+        code.contains(".amax("),
+        "should contain .amax() call (not .max() which returns (values, indices))"
+    );
+}
+
+#[test]
+fn test_codegen_fat_arrow_reshape_in_match_arm() {
+    // Construct IR directly to test reshape inside a match arm pipeline.
+    // This exercises the arm_reshape_src resolution code path in codegen.
+    let mut program = Program::new();
+    let neuron = NeuronDef {
+        name: "MatchReshape".to_string(),
+        params: vec![
+            Param { name: "dim".to_string(), default: None, type_annotation: None },
+            Param { name: "heads".to_string(), default: None, type_annotation: None },
+        ],
+        inputs: vec![Port {
+            name: "default".to_string(),
+            shape: Shape::new(vec![Dim::Wildcard, Dim::Named("seq".to_string()), Dim::Named("dim".to_string())]),
+            variadic: false,
+        }],
+        outputs: vec![Port {
+            name: "default".to_string(),
+            shape: Shape::new(vec![Dim::Wildcard, Dim::Named("heads".to_string()), Dim::Named("seq".to_string()), Dim::Named("dim".to_string())]),
+            variadic: false,
+        }],
+        max_cycle_depth: Some(10),
+        doc: None,
+        body: NeuronBody::Graph {
+            context_bindings: vec![],
+            context_unrolls: vec![],
+            connections: vec![Connection {
+                source: Endpoint::Ref(PortRef::new("in")),
+                destination: Endpoint::Match(MatchExpr {
+                    subject: MatchSubject::Implicit,
+                    arms: vec![
+                        MatchArm {
+                            pattern: MatchPattern::Shape(Shape::new(vec![
+                                Dim::Wildcard,
+                                Dim::Named("seq".to_string()),
+                                Dim::Named("d".to_string()),
+                            ])),
+                            guard: Some(Value::BinOp {
+                                op: BinOp::Gt,
+                                left: Box::new(Value::Name("d".to_string())),
+                                right: Box::new(Value::Int(256)),
+                            }),
+                            pipeline: vec![
+                                Endpoint::Reshape(ReshapeExpr {
+                                    dims: vec![
+                                        ReshapeDim::Named("batch".to_string()),
+                                        ReshapeDim::Named("seq".to_string()),
+                                        ReshapeDim::Named("heads".to_string()),
+                                        ReshapeDim::Binding {
+                                            name: "dh".to_string(),
+                                            expr: Box::new(Value::BinOp {
+                                                op: BinOp::Div,
+                                                left: Box::new(Value::Name("dim".to_string())),
+                                                right: Box::new(Value::Name("heads".to_string())),
+                                            }),
+                                        },
+                                    ],
+                                    annotation: None,
+                                    id: 10,
+                                }),
+                                Endpoint::Ref(PortRef::new("out")),
+                            ],
+                            is_reachable: true,
+                        },
+                        MatchArm {
+                            pattern: MatchPattern::Shape(Shape::new(vec![
+                                Dim::Wildcard,
+                                Dim::Named("seq".to_string()),
+                                Dim::Named("d".to_string()),
+                            ])),
+                            guard: None,
+                            pipeline: vec![
+                                Endpoint::Call {
+                                    name: "Linear".to_string(),
+                                    args: vec![Value::Name("d".to_string()), Value::Name("dim".to_string())],
+                                    kwargs: vec![],
+                                    id: 11,
+                                    frozen: false,
+                                },
+                                Endpoint::Ref(PortRef::new("out")),
+                            ],
+                            is_reachable: true,
+                        },
+                    ],
+                    id: 0,
+                }),
+            }],
+        },
+    };
+
+    program.neurons.insert("MatchReshape".to_string(), neuron);
+
+    let result = generate_pytorch(&program, "MatchReshape");
+    assert!(result.is_ok(), "codegen should succeed: {:?}", result);
+    let code = result.unwrap();
+    println!("=== RESHAPE IN MATCH ARM ===\n{}", code);
+    assert!(
+        code.contains(".reshape("),
+        "should contain reshape call inside match arm"
+    );
+    assert!(
+        code.contains("class MatchReshape(nn.Module)"),
+        "should have class definition"
+    );
+}

--- a/src/codegen/utils.rs
+++ b/src/codegen/utils.rs
@@ -8,6 +8,11 @@ use std::collections::HashSet;
 
 /// Map a BinOp to its Python operator string.
 /// When `int_div` is true, `Div` maps to `//` (integer division for dimension arithmetic).
+///
+/// Design note: Dimension expressions (reshape targets, shape computations) use integer
+/// division `//` because tensor dimensions are always integers. General value expressions
+/// (neuron parameter arithmetic) use float division `/` to preserve Python semantics.
+/// The caller chooses via `int_div` depending on context.
 pub(super) fn binop_to_str(op: &BinOp, int_div: bool) -> &'static str {
     match op {
         BinOp::Add => "+",

--- a/src/validator/symbol_table.rs
+++ b/src/validator/symbol_table.rs
@@ -436,12 +436,9 @@ pub(super) fn check_port_compatibility(
 ) -> Vec<ValidationError> {
     let mut errors = Vec::new();
 
-    // When source is a Reshape, its to_shape() gives the output shape.
-    // Validate that against the destination's input ports normally.
-    if matches!(source_endpoint, Endpoint::Reshape(_)) {
-        // source_ports already contains the reshape's output shape (from resolve_endpoint).
-        // Fall through to normal port compatibility checking below.
-    }
+    // When source is a Reshape, source_ports already contains the reshape's
+    // output shape (from resolve_endpoint). Normal port compatibility checking
+    // below handles this case.
 
     // When destination is a Reshape, the reshape consumes any input shape.
     // For bare reshapes (no annotation), check element-count preservation
@@ -578,27 +575,8 @@ pub(super) fn extract_node_name(endpoint: &Endpoint) -> String {
     }
 }
 
-/// Compute the product of all dims when all source ports have fully literal shapes.
-/// Returns None if any dim is not a Literal or if there are no ports.
-fn literal_product(ports: &[Port]) -> Option<i64> {
-    if ports.is_empty() {
-        return None;
-    }
-    let mut product: i64 = 1;
-    for port in ports {
-        for dim in &port.shape.dims {
-            match dim {
-                Dim::Literal(n) => {
-                    product = product.checked_mul(*n)?;
-                }
-                _ => return None,
-            }
-        }
-    }
-    Some(product)
-}
-
 /// Compute the product of all dims in a shape when all are Literal.
+/// Returns None if any dim is not a Literal.
 fn shape_literal_product(shape: &Shape) -> Option<i64> {
     let mut product: i64 = 1;
     for dim in &shape.dims {
@@ -608,6 +586,19 @@ fn shape_literal_product(shape: &Shape) -> Option<i64> {
             }
             _ => return None,
         }
+    }
+    Some(product)
+}
+
+/// Compute the product of all dims across all port shapes when all are Literal.
+/// Returns None if any dim is not a Literal or if there are no ports.
+fn literal_product(ports: &[Port]) -> Option<i64> {
+    if ports.is_empty() {
+        return None;
+    }
+    let mut product: i64 = 1;
+    for port in ports {
+        product = product.checked_mul(shape_literal_product(&port.shape)?)?;
     }
     Some(product)
 }


### PR DESCRIPTION
## Summary

- Remove dead-code block in `check_port_compatibility` (empty `if matches!` that just fell through)
- Unify `@repeat(copy)` expand branches — both paths now use `current` instead of diverging on `source_var` vs `current`
- Deduplicate `literal_product`/`shape_literal_product` by implementing `literal_product` in terms of `shape_literal_product`
- Document the intentional `Div` `//` vs `/` asymmetry between dimension expressions (integer division) and general value expressions (float division) in both `binop_to_str` and `dim_expr_to_python`
- Add codegen tests for `@reduce(min)` → `.amin()` and `@reduce(max)` → `.amax()`
- Add codegen test for reshape inside a match arm pipeline (exercises `arm_reshape_src` resolution)

## Test plan

- [x] All 267 existing tests pass (`cargo test`)
- [x] 3 new codegen tests pass: `test_codegen_fat_arrow_reduce_min`, `test_codegen_fat_arrow_reduce_max`, `test_codegen_fat_arrow_reshape_in_match_arm`
- [x] Integration snapshot tests unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)