### PR TITLE
fix: handle Endpoint::Reshape in WASM build

### DIFF
--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -202,6 +202,7 @@ fn collect_calls(endpoint: &Endpoint, called: &mut HashSet<String>) {
             }
         }
         Endpoint::Ref(_) => {}
+        Endpoint::Reshape(_) => {} // Reshape is a pure data transform — no neuron calls
     }
 }
 
@@ -411,6 +412,7 @@ fn format_endpoint(endpoint: &Endpoint) -> String {
         }
         Endpoint::Match(_) => "match { ... }".to_string(),
         Endpoint::If(_) => "if { ... }".to_string(),
+        Endpoint::Reshape(r) => format!("=> {}", r),
     }
 }
 
@@ -451,6 +453,6 @@ fn collect_match_exprs(neuron_name: &str, endpoint: &Endpoint, result: &mut Vec<
                 }
             }
         }
-        Endpoint::Tuple(_) | Endpoint::Call { .. } | Endpoint::Ref(_) => {}
+        Endpoint::Tuple(_) | Endpoint::Call { .. } | Endpoint::Ref(_) | Endpoint::Reshape(_) => {}
     }
 }


### PR DESCRIPTION
## Summary
- The fat arrow (`=>`) shape transform feature (PR #34) added `Endpoint::Reshape` to the IR enum but didn't update the three match arms in `src/wasm.rs`, breaking the WASM build target
- Added proper handling for `Reshape` in `collect_calls` (no-op — pure data transform), `format_endpoint` (displays as `=> [dims]`), and `collect_match_exprs` (no-op — no nested match expressions)

## Test plan
- [x] WASM build passes: `cargo check --target wasm32-unknown-unknown --no-default-features --features wasm,pest-parser --lib`
- [x] Regular build passes: `cargo check`
- [x] All tests pass: `cargo test` (27 integration + unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)