### PR TITLE
fix(REGISTRY-1): remove panicking Default impl for Registry

### DIFF
--- a/src/package/registry.rs
+++ b/src/package/registry.rs
@@ -329,12 +329,6 @@ impl Registry {
     }
 }
 
-impl Default for Registry {
-    fn default() -> Self {
-        Self::new().expect("Failed to create default registry")
-    }
-}
-
 /// Cache statistics
 #[derive(Debug, Default)]
 pub struct CacheStats {


### PR DESCRIPTION
## Fix: REGISTRY-1 (critical)

Removed unused `impl Default for Registry` that panics via `.expect()` when home directory is unavailable.

- [x] `cargo check` passes
- [x] All tests pass