### PR TITLE
fix(WASM-1): replace unsafe unwrap() in wasm.rs

### DIFF
--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -156,10 +156,9 @@ fn find_entry_point(program: &Program) -> Option<String> {
 
     let mut roots: Vec<String> = program
         .neurons
-        .keys()
-        .filter(|name| !called.contains(*name))
-        .filter(|name| !program.neurons.get(*name).unwrap().is_primitive())
-        .cloned()
+        .iter()
+        .filter(|(name, neuron)| !called.contains(*name) && !neuron.is_primitive())
+        .map(|(name, _)| name.clone())
         .collect();
 
     roots.sort();
@@ -233,7 +232,9 @@ pub fn analyze(source: &str) -> Result<String, String> {
     neuron_names.sort();
 
     for name in neuron_names {
-        let neuron = program.neurons.get(&name).unwrap();
+        let Some(neuron) = program.neurons.get(&name) else {
+            continue;
+        };
 
         let params: Vec<ParamInfo> = neuron
             .params


### PR DESCRIPTION
## Fix: WASM-1 (critical)

Replaced 2 unsafe `unwrap()` calls on HashMap lookups that could panic:
1. `find_entry_point()`: Use `.iter()` instead of `.keys()` + `.get().unwrap()`
2. `analyze()`: Use `let-else` with `continue` instead of `.unwrap()`

- [x] `cargo check` passes