### PR TITLE
fix: replace hardcoded deploy path with env var

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -7,7 +7,7 @@
     "start": "docusaurus start",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
-    "deploy": "cp -r build/* /Users/tquick/projects/neuroscript-docs/",
+    "deploy": "cp -r build/* ${NEUROSCRIPT_DOCS_DIR:-../neuroscript-docs}/",
     "clear": "docusaurus clear",
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",


### PR DESCRIPTION
## Summary
- Replaces hardcoded local path in `website/package.json` deploy script
- Uses `${NEUROSCRIPT_DOCS_DIR:-../neuroscript-docs}/` for portability across developer machines

## Review Finding
Addresses PR32-2 from codebase review.

## Test plan
- [x] Deploy script uses env var with sensible default fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)