### PR TITLE
fix: handle Others and expression dims in @repeat(copy)

### DIFF
--- a/src/codegen/forward.rs
+++ b/src/codegen/forward.rs
@@ -1156,7 +1156,21 @@ fn process_destination(
                                     true
                                 }
                                 ReshapeDim::Named(n) => !source_dim_names.contains(n),
-                                _ => false,
+                                ReshapeDim::Binding { name, .. } => {
+                                    !source_dim_names.contains(name)
+                                }
+                                ReshapeDim::Expr(_) => {
+                                    // Expressions reference existing dims; not new
+                                    false
+                                }
+                                ReshapeDim::Others => {
+                                    // Others represents a variable number of remaining
+                                    // dims and cannot map to a single expand() slot.
+                                    return Err(CodegenError::UnsupportedFeature(
+                                        "Others (`...`) cannot appear in @repeat(copy) target shape: \
+                                         expand() requires fixed-rank dimensions".to_string(),
+                                    ));
+                                }
                             };
                             if is_new {
                                 unsqueeze_indices.push(i);


### PR DESCRIPTION
## Summary
- Replaces catch-all `_ => false` with exhaustive match arms for `ReshapeDim` variants in expand() codegen
- `Others` now returns a proper error instead of silently misclassifying
- `Binding` correctly checks source dimension names
- `Expr` returns false (references existing dims, not new ones)

## Review Finding
Addresses PR34-57 from codebase review.

## Test plan
- [x] `cargo test` — all 277 unit + 27 integration tests pass
- [x] Exhaustive match prevents future variants from being silently ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)