### PR TITLE
fix: correct Einsum docstring to match 2-port interface

### DIFF
--- a/stdlib/primitives/Einsum.ns
+++ b/stdlib/primitives/Einsum.ns
@@ -13,7 +13,7 @@
 ///
 /// Notes:
 /// - No learnable parameters (pure operation)
-/// - Supports 1-3 input tensors depending on equation
+/// - Supports 2 input tensors (ports a and b)
 /// - Examples:
 ///   - "ij->ji" - transpose
 ///   - "bij,bjk->bik" - batched matrix multiply


### PR DESCRIPTION
## Summary
- Fixes Einsum stdlib docstring: claimed "1-3 input tensors" but neuron declares exactly 2 ports (`in a`, `in b`)

## Review Finding
Addresses PR37-1 from codebase review.

## Test plan
- [x] Docstring matches actual port declarations

🤖 Generated with [Claude Code](https://claude.com/claude-code)