### PR TITLE
fix: add SourceSpan to InvalidReshape/InvalidAnnotation errors

### DIFF
--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -683,11 +683,15 @@ pub enum ValidationError {
     InvalidReshape {
         message: String,
         context: String,
+        /// Source span for diagnostic reporting
+        span: Option<SourceSpan>,
     },
     InvalidAnnotation {
         annotation: String,
         reason: String,
         context: String,
+        /// Source span for diagnostic reporting
+        span: Option<SourceSpan>,
     },
     Custom(String),
     UseError {
@@ -786,13 +790,14 @@ impl std::fmt::Display for ValidationError {
                     neuron, reason
                 )
             }
-            ValidationError::InvalidReshape { message, context } => {
+            ValidationError::InvalidReshape { message, context, .. } => {
                 write!(f, "Invalid reshape: {} (in {})", message, context)
             }
             ValidationError::InvalidAnnotation {
                 annotation,
                 reason,
                 context,
+                ..
             } => {
                 write!(
                     f,

--- a/src/validator/core.rs
+++ b/src/validator/core.rs
@@ -275,6 +275,7 @@ impl Validator {
                     errors.push(ValidationError::InvalidReshape {
                         message: "reshape expression must have at least one dimension".to_string(),
                         context: format!("in {}", context_neuron),
+                        span: None, // TODO: propagate source span from ReshapeExpr
                     });
                 }
                 // Validate at most one 'others' dimension (PyTorch allows only one -1)
@@ -290,6 +291,7 @@ impl Validator {
                             others_count
                         ),
                         context: format!("in {}", context_neuron),
+                        span: None, // TODO: propagate source span from ReshapeExpr
                     });
                 }
                 if let Some(ref annotation) = reshape.annotation {
@@ -328,6 +330,7 @@ impl Validator {
                                         valid_intrinsics.join(", ")
                                     ),
                                     context: format!("in {}", context_neuron),
+                                    span: None, // TODO: propagate source span from annotation
                                 });
                             }
                         }


### PR DESCRIPTION
## Summary
- Adds `Option<SourceSpan>` fields to `InvalidReshape` and `InvalidAnnotation` error variants
- Brings these variants in line with other span-bearing errors in the `ValidationError` enum
- Currently `None` at construction sites since `ReshapeExpr` lacks span tracking (TODOs added)

## Review Finding
Addresses PR34-39 from codebase review.

## Test plan
- [x] `cargo test` — all 277 unit + 27 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)