### PR TITLE
fix: use named batch dim in fat arrow match arm test

### DIFF
--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -1016,12 +1016,12 @@ fn test_codegen_fat_arrow_reshape_in_match_arm() {
         ],
         inputs: vec![Port {
             name: "default".to_string(),
-            shape: Shape::new(vec![Dim::Wildcard, Dim::Named("seq".to_string()), Dim::Named("dim".to_string())]),
+            shape: Shape::new(vec![Dim::Named("batch".to_string()), Dim::Named("seq".to_string()), Dim::Named("dim".to_string())]),
             variadic: false,
         }],
         outputs: vec![Port {
             name: "default".to_string(),
-            shape: Shape::new(vec![Dim::Wildcard, Dim::Named("heads".to_string()), Dim::Named("seq".to_string()), Dim::Named("dim".to_string())]),
+            shape: Shape::new(vec![Dim::Named("batch".to_string()), Dim::Named("heads".to_string()), Dim::Named("seq".to_string()), Dim::Named("dim".to_string())]),
             variadic: false,
         }],
         max_cycle_depth: Some(10),
@@ -1036,7 +1036,7 @@ fn test_codegen_fat_arrow_reshape_in_match_arm() {
                     arms: vec![
                         MatchArm {
                             pattern: MatchPattern::Shape(Shape::new(vec![
-                                Dim::Wildcard,
+                                Dim::Named("batch".to_string()),
                                 Dim::Named("seq".to_string()),
                                 Dim::Named("d".to_string()),
                             ])),
@@ -1069,7 +1069,7 @@ fn test_codegen_fat_arrow_reshape_in_match_arm() {
                         },
                         MatchArm {
                             pattern: MatchPattern::Shape(Shape::new(vec![
-                                Dim::Wildcard,
+                                Dim::Named("batch".to_string()),
                                 Dim::Named("seq".to_string()),
                                 Dim::Named("d".to_string()),
                             ])),


### PR DESCRIPTION
## Summary
- Fixes `test_codegen_fat_arrow_reshape_in_match_arm` which used `Dim::Wildcard` for batch but referenced `batch` by name in reshape target
- Replaces 4 `Dim::Wildcard` uses with `Dim::Named("batch")` so generated Python has the variable defined

## Review Finding
Addresses PR35-2 from codebase review.

## Test plan
- [x] `cargo test` — all 277 unit + 27 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)