### PR TITLE
refactor: unify dim-to-Python conversion paths in codegen

### DIFF
--- a/src/codegen/forward.rs
+++ b/src/codegen/forward.rs
@@ -962,30 +962,6 @@ fn process_destination(
         Endpoint::Reshape(reshape) => {
             let result_var = make_var_name(used_var_names, "x");
 
-            // Helper closure: resolve a ReshapeDim name to a Python expression.
-            // Priority: neuron param -> self.param, binding_context, else use as-is
-            let resolve_dim_name = |name: &str| -> String {
-                if gen.current_neuron_params.contains(name) {
-                    format!("self.{}", name)
-                } else if let Some(resolved) = gen.binding_context.get(name) {
-                    resolved.clone()
-                } else {
-                    // Assume it's already in scope (from match capture, prior reshape, etc.)
-                    name.to_string()
-                }
-            };
-
-            // Convert a ReshapeDim to Python expression
-            let dim_to_py = |d: &ReshapeDim| -> Result<String, CodegenError> {
-                Ok(match d {
-                    ReshapeDim::Named(name) => resolve_dim_name(name),
-                    ReshapeDim::Literal(n) => n.to_string(),
-                    ReshapeDim::Binding { name, .. } => name.clone(),
-                    ReshapeDim::Others => "-1".to_string(),
-                    ReshapeDim::Expr(expr) => dim_expr_to_python(gen, expr)?,
-                })
-            };
-
             // Emit binding assignments for all cases (bare, @reduce, @repeat).
             // Binding dims like `dh=dim/heads` must be assigned before any use.
             for dim in &reshape.dims {
@@ -1002,7 +978,7 @@ fn process_destination(
                     let shape_args = reshape
                         .dims
                         .iter()
-                        .map(|d| dim_to_py(d))
+                        .map(|d| reshape_dim_to_python(gen, d))
                         .collect::<Result<Vec<_>, _>>()?
                         .join(", ");
 
@@ -1183,7 +1159,7 @@ fn process_destination(
                         let shape_args = reshape
                             .dims
                             .iter()
-                            .map(|d| dim_to_py(d))
+                            .map(|d| reshape_dim_to_python(gen, d))
                             .collect::<Result<Vec<_>, _>>()?
                             .join(", ");
 
@@ -1224,6 +1200,35 @@ fn process_destination(
         }
     }
 }
+/// Resolve a dimension name to a Python expression.
+///
+/// This is the single, unified path for converting dimension variable names to Python.
+/// Priority: neuron param -> `self.param`, binding_context lookup, else use as-is
+/// (assuming it's already in scope from a match capture, prior reshape, etc.).
+fn resolve_dim_name(gen: &CodeGenerator, name: &str) -> String {
+    if gen.current_neuron_params.contains(name) {
+        format!("self.{}", name)
+    } else if let Some(resolved) = gen.binding_context.get(name) {
+        resolved.clone()
+    } else {
+        name.to_string()
+    }
+}
+
+/// Convert a `ReshapeDim` to a Python expression string.
+///
+/// Handles all reshape dimension variants (named, literal, binding, others, expr)
+/// using `resolve_dim_name` for consistent name resolution.
+fn reshape_dim_to_python(gen: &CodeGenerator, d: &ReshapeDim) -> Result<String, CodegenError> {
+    Ok(match d {
+        ReshapeDim::Named(name) => resolve_dim_name(gen, name),
+        ReshapeDim::Literal(n) => n.to_string(),
+        ReshapeDim::Binding { name, .. } => name.clone(),
+        ReshapeDim::Others => "-1".to_string(),
+        ReshapeDim::Expr(expr) => dim_expr_to_python(gen, expr)?,
+    })
+}
+
 /// Convert a DimExpr to Python code for dimension arithmetic (uses // for division).
 /// Returns an error if the expression contains comparison operators, which are not
 /// valid in dimension arithmetic contexts.
@@ -1244,24 +1249,18 @@ fn dim_expr_to_python(gen: &CodeGenerator, expr: &DimExpr) -> Result<String, Cod
             )));
         }
     };
-    let left = reshape_dim_ref_to_python(gen, &expr.left)?;
-    let right = reshape_dim_ref_to_python(gen, &expr.right)?;
+    let left = dim_ref_to_python(gen, &expr.left)?;
+    let right = dim_ref_to_python(gen, &expr.right)?;
     Ok(format!("{} {} {}", left, op_str, right))
 }
 
-/// Convert a Dim (when used as part of a DimExpr in a reshape) to Python
-fn reshape_dim_ref_to_python(gen: &CodeGenerator, dim: &Dim) -> Result<String, CodegenError> {
+/// Convert a Dim (when used as part of a DimExpr in a reshape) to Python.
+///
+/// Uses `resolve_dim_name` for consistent name resolution across all dim-to-Python paths.
+fn dim_ref_to_python(gen: &CodeGenerator, dim: &Dim) -> Result<String, CodegenError> {
     Ok(match dim {
         Dim::Literal(n) => n.to_string(),
-        Dim::Named(n) => {
-            if gen.current_neuron_params.contains(n) {
-                format!("self.{}", n)
-            } else if let Some(resolved) = gen.binding_context.get(n) {
-                resolved.clone()
-            } else {
-                n.clone()
-            }
-        }
+        Dim::Named(n) => resolve_dim_name(gen, n),
         Dim::Global(n) => n.clone(),
         Dim::Expr(e) => dim_expr_to_python(gen, e)?,
         Dim::Wildcard => "-1".to_string(),


### PR DESCRIPTION
## Summary
- Extracts shared name-resolution into single `resolve_dim_name()` function
- Replaces duplicated inline closures with standalone `reshape_dim_to_python()` and `dim_ref_to_python()`
- Eliminates risk of divergence between the two conversion paths

## Review Finding
Addresses PR34-59 from codebase review.

## Test plan
- [x] `cargo test` — all 277 unit + 27 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)