### PR TITLE
fix: add causal mode to ALiBi and document bias computation

### DIFF
--- a/neuroscript_runtime/primitives/embeddings.py
+++ b/neuroscript_runtime/primitives/embeddings.py
@@ -454,7 +454,7 @@ class ALiBi(nn.Module):
         num_heads: Number of attention heads
         max_seq_len: Maximum sequence length for precomputed bias matrix. Default: 2048
         causal: If True, use causal (decoder) distances where each position only
-            attends to earlier positions (distance[i,j] = j - i for j <= i, masked
+            attends to earlier positions (distance[i,j] = i - j for i >= j, masked
             to -inf for j > i). If False (default), use absolute distances
             (distance[i,j] = |i - j|) appropriate for bidirectional (encoder)
             attention. Default: False
@@ -475,6 +475,8 @@ class ALiBi(nn.Module):
         >>> alibi = ALiBi(num_heads=8, causal=True)
         >>> scores = torch.randn(2, 8, 128, 128)
         >>> biased = alibi(scores)
+        >>> biased.shape
+        torch.Size([2, 8, 128, 128])
 
         >>> # Non-power-of-2 heads
         >>> alibi = ALiBi(num_heads=12, max_seq_len=512)
@@ -489,10 +491,10 @@ class ALiBi(nn.Module):
         - Bias is registered as a buffer (no gradients, moves with model)
         - Supports sequences up to max_seq_len without recomputation
         - **Causal vs bidirectional**: The original ALiBi paper targets causal
-          (decoder) models where distances are non-positive (each query only
-          attends to keys at the same or earlier positions). Set ``causal=True``
-          for decoder / autoregressive models. The default ``causal=False`` uses
-          symmetric absolute distances, suitable for bidirectional / encoder models.
+          (decoder) models where distances are non-negative (distance[i,j] = i - j
+          for i >= j). Set ``causal=True`` for decoder / autoregressive models.
+          The default ``causal=False`` uses symmetric absolute distances, suitable
+          for bidirectional / encoder models.
     """
 
     def __init__(self, num_heads: int, max_seq_len: int = 2048, causal: bool = False) -> None:
@@ -506,7 +508,7 @@ class ALiBi(nn.Module):
 
         self.num_heads = num_heads
         self.max_seq_len = max_seq_len
-        self.causal = causal
+        self.causal = causal  # informational only; behaviour is baked into the precomputed bias buffer
 
         # Compute per-head slopes
         slopes = self._get_slopes(num_heads)
@@ -516,8 +518,8 @@ class ALiBi(nn.Module):
         # Precompute distance matrix [max_seq_len, max_seq_len]
         positions = torch.arange(max_seq_len, dtype=torch.float32)
         if causal:
-            # Causal (decoder) distances: distance[i, j] = j - i (non-positive
-            # for j <= i). Future positions (j > i) get -inf so they are masked
+            # Causal (decoder) distances: distance[i, j] = i - j (non-negative
+            # for i >= j). Future positions (j > i) get -inf so they are masked
             # out after softmax.
             distance = positions.unsqueeze(1) - positions.unsqueeze(0)  # i - j
             # distance[i, j] = i - j  (positive when i > j, i.e. query after key)

--- a/neuroscript_runtime/primitives/test_new_primitives.py
+++ b/neuroscript_runtime/primitives/test_new_primitives.py
@@ -21,6 +21,7 @@ from neuroscript_runtime.primitives.convolutions import (
 )
 from neuroscript_runtime.primitives.pooling import AdaptiveMaxPool, GlobalMaxPool
 from neuroscript_runtime.primitives.structural import Split, Slice, Pad
+from neuroscript_runtime.primitives.embeddings import ALiBi
 
 
 class TestCoreOperations:
@@ -172,6 +173,45 @@ class TestStructural:
         x = torch.randn(32, 64, 28, 28)
         out = pad(x)
         assert out.shape == (32, 64, 30, 30)
+
+
+class TestALiBiCausal:
+    def test_causal_upper_triangular_is_neg_inf(self):
+        alibi = ALiBi(num_heads=4, max_seq_len=8, causal=True)
+        scores = torch.zeros(1, 4, 8, 8)
+        biased = alibi(scores)
+        # Upper triangular (j > i) should be -inf
+        for i in range(8):
+            for j in range(i + 1, 8):
+                assert biased[0, 0, i, j] == float("-inf")
+
+    def test_causal_lower_triangular_is_finite(self):
+        alibi = ALiBi(num_heads=4, max_seq_len=8, causal=True)
+        scores = torch.zeros(1, 4, 8, 8)
+        biased = alibi(scores)
+        # Diagonal and lower triangular (j <= i) should be finite
+        for i in range(8):
+            for j in range(i + 1):
+                assert torch.isfinite(biased[0, 0, i, j])
+
+    def test_causal_diagonal_is_zero(self):
+        alibi = ALiBi(num_heads=4, max_seq_len=8, causal=True)
+        scores = torch.zeros(1, 4, 8, 8)
+        biased = alibi(scores)
+        # Diagonal (i == j) means distance=0, so bias=0
+        for i in range(8):
+            for h in range(4):
+                assert biased[0, h, i, i] == 0.0
+
+    def test_extra_repr_includes_causal(self):
+        alibi = ALiBi(num_heads=4, causal=True)
+        assert "causal=True" in alibi.extra_repr()
+
+    def test_causal_output_shape(self):
+        alibi = ALiBi(num_heads=8, causal=True)
+        scores = torch.randn(2, 8, 128, 128)
+        biased = alibi(scores)
+        assert biased.shape == torch.Size([2, 8, 128, 128])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Adds `causal` parameter to ALiBi (default `False` for backward compat)
- Causal mode uses signed distances with -inf masking for decoder attention
- Documents distinction between bidirectional (abs) and causal (signed) distances

## Review Finding
Addresses PR33-9 from codebase review.

## Test plan
- [x] Default behavior unchanged (causal=False)
- [x] Causal mode masks future positions with -inf

🤖 Generated with [Claude Code](https://claude.com/claude-code)