### PR TITLE
fix: flatten() returns Option instead of silent [0]

### DIFF
--- a/src/shape/algebra.rs
+++ b/src/shape/algebra.rs
@@ -37,13 +37,11 @@ impl Shape {
         self.size().unwrap_or(BigUint::zero())
     }
 
-    /// flatten to rank-1 shape [size]
-    pub fn flatten(&self) -> Shape {
-        let size = self
-            .size()
-            .unwrap_or(BigUint::zero())
-            .to_usize()
-            .unwrap_or(0);
-        Shape::new(vec![Dim::Literal(size as i64)]) // best-effort for small sizes
+    /// Flatten to rank-1 shape [size].
+    /// Returns `None` if the shape contains non-literal dimensions (named, variadic, wildcard)
+    /// or if the total size overflows `usize`.
+    pub fn flatten(&self) -> Option<Shape> {
+        let size = self.size()?.to_usize()?;
+        Some(Shape::new(vec![Dim::Literal(size as i64)]))
     }
 }

--- a/src/shape/tests.rs
+++ b/src/shape/tests.rs
@@ -92,21 +92,33 @@ fn test_shape_size_very_large() {
 fn test_flatten_multidim() {
     let s = Shape::new(vec![Dim::Literal(2), Dim::Literal(3), Dim::Literal(4)]);
     let flat = s.flatten();
-    assert_eq!(flat, Shape::new(vec![Dim::Literal(24)]));
+    assert_eq!(flat, Some(Shape::new(vec![Dim::Literal(24)])));
 }
 
 #[test]
 fn test_flatten_already_flat() {
     let s = Shape::new(vec![Dim::Literal(24)]);
     let flat = s.flatten();
-    assert_eq!(flat, Shape::new(vec![Dim::Literal(24)]));
+    assert_eq!(flat, Some(Shape::new(vec![Dim::Literal(24)])));
 }
 
 #[test]
 fn test_flatten_empty() {
     let s = Shape::new(vec![]);
     let flat = s.flatten();
-    assert_eq!(flat, Shape::new(vec![Dim::Literal(1)])); // Empty shape has size 1
+    assert_eq!(flat, Some(Shape::new(vec![Dim::Literal(1)]))); // Empty shape has size 1 (product of no dims)
+}
+
+#[test]
+fn test_flatten_named_dims_returns_none() {
+    let s = Shape::new(vec![Dim::Named("batch".to_string()), Dim::Literal(256)]);
+    assert_eq!(s.flatten(), None); // Cannot flatten when dimensions are unknown
+}
+
+#[test]
+fn test_flatten_wildcard_returns_none() {
+    let s = Shape::new(vec![Dim::Wildcard, Dim::Literal(64)]);
+    assert_eq!(s.flatten(), None); // Cannot flatten when dimensions are unknown
 }
 
 // ========================================


### PR DESCRIPTION
## Summary
- Changes `Shape::flatten()` from `Shape` to `Option<Shape>`
- Returns `None` when shape contains named/variadic dims or size overflows
- Eliminates silent production of incorrect `[0]` shape
- Adds 2 new tests for None cases

## Review Finding
Addresses SH-W4 from codebase review.

## Test plan
- [x] `cargo test` — 279 unit + 27 integration tests pass
- [x] New tests verify None returned for unknown-dim shapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)