### PR TITLE
fix: return errors for unsolvable shape expressions

### DIFF
--- a/src/shape/inference.rs
+++ b/src/shape/inference.rs
@@ -114,7 +114,10 @@ impl InferenceContext {
                     BinOp::Div => {
                         self.resolve_dim(left_name.clone(), target * (*right_val as usize))
                     }
-                    _ => Ok(()), // TODO
+                    _ => Err(format!(
+                        "Unsupported operator '{}' in dimension constraint solving: {} {} {} = {}",
+                        expr.op, left_name, expr.op, right_val, target
+                    )),
                 }
             }
             (Dim::Literal(left_val), Dim::Named(right_name)) => {
@@ -160,7 +163,10 @@ impl InferenceContext {
                             Ok(())
                         }
                     }
-                    _ => Ok(()), // TODO
+                    _ => Err(format!(
+                        "Unsupported operator '{}' in dimension constraint solving: {} {} {} = {}",
+                        expr.op, left_val, expr.op, right_name, target
+                    )),
                 }
             }
             // Solve recursive expressions
@@ -186,13 +192,21 @@ impl InferenceContext {
                         Some(target / (*right_val as usize))
                     }
                     BinOp::Div => Some(target * (*right_val as usize)),
-                    _ => None,
+                    _ => {
+                        return Err(format!(
+                            "Unsupported operator '{}' in dimension constraint solving for expression",
+                            expr.op
+                        ));
+                    }
                 };
 
                 if let Some(val) = left_val {
                     self.solve_expr_for_unknown(left_expr, val)
                 } else {
-                    Ok(()) // or error
+                    Err(format!(
+                        "Cannot solve dimension constraint: expr {} {} = {}",
+                        expr.op, right_val, target
+                    ))
                 }
             }
             (Dim::Literal(left_val), Dim::Expr(right_expr)) => {
@@ -231,16 +245,28 @@ impl InferenceContext {
                             None
                         }
                     }
-                    _ => None,
+                    _ => {
+                        return Err(format!(
+                            "Unsupported operator '{}' in dimension constraint solving for expression",
+                            expr.op
+                        ));
+                    }
                 };
 
                 if let Some(val) = right_val {
                     self.solve_expr_for_unknown(right_expr, val)
                 } else {
-                    Ok(())
+                    Err(format!(
+                        "Cannot solve dimension constraint: {} {} expr = {}",
+                        left_val, expr.op, target
+                    ))
                 }
             }
-            _ => Ok(()), // Too complex to solve for now
+            _ => Err(format!(
+                "Cannot solve dimension constraint: expression with operator '{}' is too complex \
+                 (only single-unknown equations with +, -, *, / are supported)",
+                expr.op
+            )),
         }
     }
 


### PR DESCRIPTION
## Summary
- Replaces all silent `Ok(())` returns in `solve_expr_for_unknown` with descriptive errors
- Covers: unsupported operators (comparison), negative dimensions, multi-unknown expressions
- Only `+`, `-`, `*`, `/` with single unknowns are solvable — everything else now errors clearly

## Review Finding
Addresses SH-W5 from codebase review.

## Test plan
- [x] `cargo test` — all 277 unit + 27 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)