### PR TITLE
fix: show detail panel on mobile for deep-linked neurons

### DIFF
--- a/website/src/components/NeuronGenealogy/index.js
+++ b/website/src/components/NeuronGenealogy/index.js
@@ -97,6 +97,7 @@ function NeuronGenealogyInner() {
       const decoded = decodeURIComponent(hash);
       if (neuronMap.has(decoded)) {
         setSelectedNeuron(decoded);
+        setMobileShowDetail(true);
       }
     }
 
@@ -106,6 +107,7 @@ function NeuronGenealogyInner() {
         const d = decodeURIComponent(h);
         if (neuronMap.has(d)) {
           setSelectedNeuron(d);
+          setMobileShowDetail(true);
         }
       }
     };


### PR DESCRIPTION
## Summary
- Adds `setMobileShowDetail(true)` to hash-change handler and initial mount
- Ensures deep links (e.g., `#Linear`) show the detail panel on mobile
- Matches existing `handleSelectNeuron` behavior

## Review Finding
Addresses PR38-1 from codebase review.

## Test plan
- [x] Navigate to genealogy page with hash on mobile — detail panel should show

🤖 Generated with [Claude Code](https://claude.com/claude-code)