### PR TITLE
fix: recognize sequential pseudo neuron in validator

### DIFF
--- a/src/validator/tests/valid_cases.rs
+++ b/src/validator/tests/valid_cases.rs
@@ -1,4 +1,5 @@
 use super::fixtures::*;
+use crate::interfaces::SEQUENTIAL_PSEUDO_NEURON;
 
 #[test]
 fn test_empty_graph() {
@@ -33,6 +34,24 @@ fn test_valid_pipeline() {
                 connection(ref_endpoint("in"), call_endpoint("A")),
                 connection(call_endpoint("A"), call_endpoint("B")),
                 connection(call_endpoint("B"), ref_endpoint("out")),
+            ],
+            Some(10),
+        )
+        .build();
+
+    assert_validation_ok(&mut program);
+}
+
+#[test]
+fn test_sequential_pseudo_neuron_passes_validation() {
+    // The @wrap desugar pass introduces __sequential__ as a synthetic neuron.
+    // The validator must recognise it without a user-defined definition.
+    let mut program = ProgramBuilder::new()
+        .with_composite(
+            "Wrapped",
+            vec![
+                connection(ref_endpoint("in"), call_endpoint(SEQUENTIAL_PSEUDO_NEURON)),
+                connection(call_endpoint(SEQUENTIAL_PSEUDO_NEURON), ref_endpoint("out")),
             ],
             Some(10),
         )


### PR DESCRIPTION
## Summary
- Adds test coverage confirming `SEQUENTIAL_PSEUDO_NEURON` (`__sequential__`) passes the validator existence check
- The fix in `neuron_exists()` was already in place; this PR adds the missing test
- Prevents regression of spurious "missing neuron" errors from @wrap desugaring

## Story
FE-NEW-1 from NS Board kanban

## Test plan
- [x] New test `test_sequential_pseudo_neuron_passes_validation` passes
- [x] All existing tests pass (`cargo test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)