### PR TITLE
test: e2e codegen snapshot with adversarial identifiers

### DIFF
--- a/examples/adversarial_identifiers.ns
+++ b/examples/adversarial_identifiers.ns
@@ -1,0 +1,20 @@
+# Test file: adversarial identifiers that are Python keywords
+#
+# NeuroScript allows these as valid identifiers, but the codegen
+# must sanitize them (append '_') to produce valid Python.
+
+neuron AdversarialNet(lambda, dim):
+    in: [batch, lambda]
+    out: [batch, dim]
+    graph:
+        in -> Linear(lambda, dim) -> ReLU() -> out
+
+neuron Linear(in_dim, out_dim):
+    in: [*, in_dim]
+    out: [*, out_dim]
+    impl: core,nn/Linear
+
+neuron ReLU:
+    in: [*shape]
+    out: [*shape]
+    impl: core,nn/ReLU

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -911,6 +911,52 @@ fn snapshot_all_examples() {
 }
 
 // ============================================================================
+// Sanitization / Adversarial Identifier Tests
+// ============================================================================
+
+#[test]
+fn snapshot_codegen_adversarial_identifiers() {
+    // Python keywords as NeuroScript param/dimension names.
+    // The sanitizer must append '_' to produce valid Python.
+    let source = r#"
+neuron AdversarialNet(lambda, dim):
+    in: [batch, lambda]
+    out: [batch, dim]
+    graph:
+        in -> Linear(lambda, dim) -> ReLU() -> out
+
+neuron Linear(in_dim, out_dim):
+    in: [*, in_dim]
+    out: [*, out_dim]
+    impl: core,nn/Linear
+
+neuron ReLU:
+    in: [*shape]
+    out: [*shape]
+    impl: core,nn/ReLU
+"#;
+
+    let mut program = parse(source).expect("Parse failed");
+    validate(&mut program).expect("Validation failed");
+
+    let code = generate_pytorch(&program, "AdversarialNet").expect("Codegen failed");
+
+    // Verify 'lambda' (Python keyword) is sanitized to 'lambda_'
+    assert!(
+        !code.contains("self.lambda =") && !code.contains("self.lambda,"),
+        "Generated Python must not use bare 'lambda' as identifier.\nGot:\n{}",
+        code
+    );
+    assert!(
+        code.contains("lambda_"),
+        "Expected 'lambda' to be sanitized to 'lambda_'.\nGot:\n{}",
+        code
+    );
+
+    insta::assert_snapshot!("codegen_adversarial_identifiers", code);
+}
+
+// ============================================================================
 // Bundle Mode Tests
 // ============================================================================
 

--- a/tests/snapshots/integration_tests__codegen_adversarial_identifiers.snap
+++ b/tests/snapshots/integration_tests__codegen_adversarial_identifiers.snap
@@ -1,0 +1,22 @@
+---
+source: tests/integration_tests.rs
+expression: code
+---
+import torch
+import torch.nn as nn
+from neuroscript_runtime.primitives.activations import ReLU
+from neuroscript_runtime.primitives.linear import Linear
+
+class AdversarialNet(nn.Module):
+    def __init__(self, lambda_, dim):
+        super().__init__()
+        self.lambda_ = lambda_
+        self.dim = dim
+        self.linear_0 = Linear(lambda_, dim)
+        self.re_l_u_1 = ReLU()
+
+    def forward(self, x):
+        linear_0 = self.linear_0(x)
+        # Linear() output shape: [*, out_dim]
+        re_l_u_1 = self.re_l_u_1(linear_0)
+        return re_l_u_1

--- a/tests/snapshots/integration_tests__example_adversarial_identifiers.snap
+++ b/tests/snapshots/integration_tests__example_adversarial_identifiers.snap
@@ -1,0 +1,31 @@
+---
+source: tests/integration_tests.rs
+expression: formatted
+---
+=== Neurons ===
+
+neuron AdversarialNet(lambda, dim):
+  inputs:
+    default: [batch, lambda]
+  outputs:
+    default: [batch, dim]
+  graph:
+    in -> Linear#0(lambda, dim)
+    Linear#0(lambda, dim) -> ReLU#1()
+    ReLU#1() -> out
+
+neuron Linear(in_dim, out_dim):
+  inputs:
+    default: [*, in_dim]
+  outputs:
+    default: [*, out_dim]
+  impl:
+    Source: core,nn/Linear
+
+neuron ReLU:
+  inputs:
+    default: [*shape]
+  outputs:
+    default: [*shape]
+  impl:
+    Source: core,nn/ReLU


### PR DESCRIPTION
## Summary

- Add `examples/adversarial_identifiers.ns` with Python keyword param names (`lambda`)
- Add codegen snapshot test verifying `sanitize_python_ident()` produces valid Python (`lambda` -> `lambda_`)
- Parser IR snapshot also added via `snapshot_all_examples`

## Test plan

- [x] `neuroscript validate examples/adversarial_identifiers.ns` parses successfully
- [x] Codegen snapshot confirms `lambda` is sanitized to `lambda_` in all positions (class param, self assignment, module instantiation)
- [x] Assertion checks no bare `lambda` appears as Python identifier
- [x] All 31 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)