### PR TITLE
fix: render all validation errors regardless of ordering

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1242,6 +1242,7 @@ fn render_validation_errors(
     let source = fs::read_to_string(file).ok();
 
     let mut first_report: Option<miette::Report> = None;
+    let mut plain_errors: Vec<String> = Vec::new();
 
     for error in errors {
         if error.span().is_some() {
@@ -1259,10 +1260,13 @@ fn render_validation_errors(
                 continue;
             }
         }
-        // No span or no source — print as plain text
-        if first_report.is_some() {
-            eprintln!("  {}", error);
-        }
+        // No span or no source — always collect for display
+        plain_errors.push(format!("  {}", error));
+    }
+
+    // Print all non-spanned errors regardless of ordering
+    for msg in &plain_errors {
+        eprintln!("{}", msg);
     }
 
     if let Some(report) = first_report {
@@ -1270,11 +1274,7 @@ fn render_validation_errors(
     }
 
     // Fallback: no spanned errors, use the old-style summary
-    let detail = errors
-        .iter()
-        .map(|e| format!("  {}", e))
-        .collect::<Vec<_>>()
-        .join("\n");
+    let detail = plain_errors.join("\n");
     Err(miette::miette!(
         "Validation failed with {} error(s):\n{}",
         errors.len(),


### PR DESCRIPTION
## Summary
- Non-spanned errors appearing before the first spanned error were silently dropped
- The `if first_report.is_some()` guard prevented their display
- Now collects all non-spanned errors and prints them unconditionally

Found by claude-review on PR #100.

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` passes
- [ ] CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)