### PR TITLE
fix: prevent double output of non-spanned validation errors

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1274,11 +1274,7 @@ fn render_validation_errors(
 
     // Fallback: no spanned errors — return all as a single error (no eprintln
     // here to avoid double output since the caller will display the returned error)
-    let detail = errors
-        .iter()
-        .map(|e| format!("  {}", e))
-        .collect::<Vec<_>>()
-        .join("\n");
+    let detail = plain_errors.join("\n");
     Err(miette::miette!(
         "Validation failed with {} error(s):\n{}",
         errors.len(),


### PR DESCRIPTION
## Summary
- Non-spanned errors were printed to stderr AND embedded in the returned miette error
- Users saw each message twice when all errors lacked source spans
- Now only prints non-spanned to stderr when mixed with spanned errors (for context)
- All-non-spanned case relies solely on the return value

Found by claude-review on PR #100 (second review pass). Fixes CLI-NEW-3.

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` passes
- [ ] CI checks

Generated with [Claude Code](https://claude.com/claude-code)