### PR TITLE
fix: include port names and shapes in PortMismatch error messages

### DIFF
--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -696,7 +696,7 @@ pub enum ValidationError {
         #[label("not found")]
         span: Option<SourceSpan>,
     },
-    #[error("Port mismatch: {context}")]
+    #[error("Port mismatch: {source_node}.{source_port} {source_shape} -> {dest_node}.{dest_port} {dest_shape} (in {context})")]
     #[diagnostic(help("check if dimensions match or if a transpose/reshape is needed"))]
     PortMismatch {
         source_node: String,


### PR DESCRIPTION
## Summary
- Updated the `#[error(...)]` attribute on `PortMismatch` to include `source_node.source_port source_shape -> dest_node.dest_port dest_shape (in context)` instead of just `{context}`
- All previously unused fields (`source_node`, `source_port`, `source_shape`, `dest_node`, `dest_port`, `dest_shape`) are now visible in error output
- Error remains readable in both miette-spanned and plain text contexts

## Test plan
- [x] `cargo test` -- all 31 tests pass
- [x] `cargo build --release` -- compiles cleanly
- [x] No snapshot changes (no snapshots reference PortMismatch error text)

Closes CODEGEN-8

Generated with [Claude Code](https://claude.com/claude-code)