### PR TITLE
fix: unify lazy instantiation codegen paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "neuroscript"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "dirs",

--- a/src/codegen/forward.rs
+++ b/src/codegen/forward.rs
@@ -73,6 +73,55 @@ fn emit_bound_module_shape_comment(
     }
 }
 
+/// Generate lazy instantiation guard code for a module.
+///
+/// Both the Ref path (context bindings) and Call path (inline calls) use this
+/// unified function to emit the `if self._mod is None: self._mod = Cls(args)`
+/// pattern, resolving argument names through `var_names`.
+fn emit_lazy_instantiation(
+    gen: &CodeGenerator,
+    output: &mut String,
+    module_ref: &str,
+    call_name: &str,
+    args: &[Value],
+    kwargs: &[Kwarg],
+    indent: &str,
+) {
+    let args_str = args
+        .iter()
+        .map(|v| value_to_python_with_vars(v, &gen.var_names))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    let kwargs_str = if kwargs.is_empty() {
+        String::new()
+    } else {
+        let kw: Vec<String> = kwargs
+            .iter()
+            .map(|(k, v)| {
+                format!(
+                    "{}={}",
+                    sanitize_python_ident(k),
+                    value_to_python_with_vars(v, &gen.var_names)
+                )
+            })
+            .collect();
+        if args.is_empty() {
+            kw.join(", ")
+        } else {
+            format!(", {}", kw.join(", "))
+        }
+    };
+
+    writeln!(output, "{}if {} is None:", indent, module_ref).unwrap();
+    writeln!(
+        output,
+        "{}    {} = {}({}{})",
+        indent, module_ref, call_name, args_str, kwargs_str
+    )
+    .unwrap();
+}
+
 /// Emit a shape comment and optional assertion for a variable at a Ref destination.
 /// Suppresses comments for _unroll temp refs and when shape hasn't changed.
 fn emit_shape_comment_and_assertion(
@@ -490,53 +539,19 @@ fn process_destination(
                         }
                     }
 
-                    // Check if this is a lazy binding (starts with "self._")
-                    if module_ref.starts_with("self._")
-                        && gen.lazy_bindings.contains_key(&port_ref.node)
+                    // Check if this is a lazy binding via lazy_bindings lookup
+                    if let Some((call_name, lazy_args, lazy_kwargs)) =
+                        gen.lazy_bindings.get(&port_ref.node).cloned()
                     {
-                        // Generate lazy instantiation code
-                        let (call_name, args, kwargs) =
-                            gen.lazy_bindings.get(&port_ref.node).ok_or_else(|| {
-                                CodegenError::InvalidConnection(format!(
-                                    "Lazy binding '{}' not found in codegen context",
-                                    port_ref.node
-                                ))
-                            })?;
-
-                        let args_str = args
-                            .iter()
-                            .map(|v| value_to_python_with_vars(v, &gen.var_names))
-                            .collect::<Vec<_>>()
-                            .join(", ");
-
-                        let kwargs_str = if kwargs.is_empty() {
-                            String::new()
-                        } else {
-                            let kw: Vec<String> = kwargs
-                                .iter()
-                                .map(|(k, v)| {
-                                    format!(
-                                        "{}={}",
-                                        sanitize_python_ident(k),
-                                        value_to_python_with_vars(v, &gen.var_names)
-                                    )
-                                })
-                                .collect();
-                            if args.is_empty() {
-                                kw.join(", ")
-                            } else {
-                                format!(", {}", kw.join(", "))
-                            }
-                        };
-
-                        // Generate lazy instantiation check
-                        writeln!(output, "{}if {} is None:", indent, module_ref).unwrap();
-                        writeln!(
+                        emit_lazy_instantiation(
+                            gen,
                             output,
-                            "{}    {} = {}({}{})",
-                            indent, module_ref, call_name, args_str, kwargs_str
-                        )
-                        .unwrap();
+                            &module_ref,
+                            &call_name,
+                            &lazy_args,
+                            &lazy_kwargs,
+                            indent,
+                        );
                     }
 
                     // This is a bound module - generate a call with semantic name
@@ -601,8 +616,8 @@ fn process_destination(
         }
         Endpoint::Call {
             name,
-            args,
-            kwargs,
+            args: _,
+            kwargs: _,
             id,
             frozen: _,
         } => {
@@ -615,62 +630,30 @@ fn process_destination(
             // Semantic name from module attribute name
             let result_var = make_var_name(used_var_names, &module_name);
 
-            // Check if this call has captured dimensions (needs lazy instantiation)
-            let has_captured = args
-                .iter()
-                .any(|v| has_captured_dimensions_impl(v, &gen.current_neuron_params))
-                || kwargs
-                    .iter()
-                    .any(|(_, v)| has_captured_dimensions_impl(v, &gen.current_neuron_params));
-
-            if has_captured {
-                // Lazy instantiation: check cache, instantiate if needed
-                writeln!(output, "{}if self._{} is None:", indent, module_name).unwrap();
-
-                // Generate instantiation with current dimension values.
-                // Use value_to_python_with_vars to resolve context binding names
-                // (e.g., "attn" → "self.attn") and parameter names (e.g., "n" → "self.n").
-                let args_str = args
-                    .iter()
-                    .map(|v| value_to_python_with_vars(v, &gen.var_names))
-                    .collect::<Vec<_>>()
-                    .join(", ");
-
-                let kwargs_str = if kwargs.is_empty() {
-                    String::new()
-                } else {
-                    let kw: Vec<String> = kwargs
-                        .iter()
-                        .map(|(k, v)| {
-                            format!(
-                                "{}={}",
-                                sanitize_python_ident(k),
-                                value_to_python_with_vars(v, &gen.var_names)
-                            )
-                        })
-                        .collect();
-                    if args.is_empty() {
-                        kw.join(", ")
-                    } else {
-                        format!(", {}", kw.join(", "))
-                    }
-                };
+            // Check if this call needs lazy instantiation by looking up
+            // lazy_bindings (unified with the Ref path above).
+            if let Some((call_name, lazy_args, lazy_kwargs)) =
+                gen.lazy_bindings.get(&module_name).cloned()
+            {
+                let module_ref = format!("self._{}", module_name);
+                emit_lazy_instantiation(
+                    gen,
+                    output,
+                    &module_ref,
+                    &call_name,
+                    &lazy_args,
+                    &lazy_kwargs,
+                    indent,
+                );
 
                 // Mark as primitive for imports
-                if let Some(neuron) = gen.program.neurons.get(name.as_str()) {
+                if let Some(neuron) = gen.program.neurons.get(call_name.as_str()) {
                     if neuron.is_primitive() {
-                        gen.used_primitives.insert(name.clone());
+                        gen.used_primitives.insert(call_name.clone());
                     }
                 } else {
-                    gen.used_primitives.insert(name.clone());
+                    gen.used_primitives.insert(call_name.clone());
                 }
-
-                writeln!(
-                    output,
-                    "{}    self._{} = {}({}{})",
-                    indent, module_name, name, args_str, kwargs_str
-                )
-                .unwrap();
 
                 // Call the lazily-instantiated module
                 writeln!(

--- a/src/codegen/instantiation.rs
+++ b/src/codegen/instantiation.rs
@@ -343,6 +343,13 @@ pub(super) fn generate_module_instantiations(
                 module_name
             )
             .unwrap();
+
+            gen.lazy_bindings.insert(
+                module_name.clone(),
+                (name.clone(), args.clone(), kwargs.clone()),
+            );
+            gen.var_names
+                .insert(module_name.clone(), format!("self._{}", module_name));
             instantiated_count += 1;
             continue;
         }

--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -1225,3 +1225,134 @@ neuron Test(dim):
         code
     );
 }
+
+#[test]
+fn test_lazy_binding_cross_referencing_context_bindings() {
+    // Context bindings that reference each other should produce valid Python.
+    // Binding "adapter" is @lazy and references binding "proj" as an arg.
+    // The generated code must resolve "proj" to "self.proj", not bare "proj".
+    let mut program = Program::new();
+
+    // Register Linear as a primitive so codegen can find it
+    let linear_neuron = NeuronDef {
+        name: "Linear".to_string(),
+        params: vec![
+            Param { name: "in_features".to_string(), default: None, type_annotation: None },
+            Param { name: "out_features".to_string(), default: None, type_annotation: None },
+        ],
+        inputs: vec![Port {
+            name: "default".to_string(),
+            shape: Shape::new(vec![Dim::Wildcard, Dim::Named("in_features".to_string())]),
+            variadic: false,
+        }],
+        outputs: vec![Port {
+            name: "default".to_string(),
+            shape: Shape::new(vec![Dim::Wildcard, Dim::Named("out_features".to_string())]),
+            variadic: false,
+        }],
+        max_cycle_depth: Some(10),
+        doc: None,
+        body: NeuronBody::Primitive(ImplRef::Source {
+            source: "core".to_string(),
+            path: "nn/Linear".to_string(),
+        }),
+    };
+    program.neurons.insert("Linear".to_string(), linear_neuron);
+
+    // Composite neuron with two bindings: proj (eager) and adapter (@lazy).
+    // adapter's args include "proj" -- a reference to the other binding's name.
+    // This tests that the lazy instantiation code resolves "proj" via var_names
+    // to "self.proj" instead of emitting the bare name "proj".
+    let neuron = NeuronDef {
+        name: "CrossRefLazy".to_string(),
+        params: vec![
+            Param { name: "dim".to_string(), default: None, type_annotation: None },
+        ],
+        inputs: vec![Port {
+            name: "default".to_string(),
+            shape: Shape::new(vec![Dim::Wildcard, Dim::Named("dim".to_string())]),
+            variadic: false,
+        }],
+        outputs: vec![Port {
+            name: "default".to_string(),
+            shape: Shape::new(vec![Dim::Wildcard, Dim::Named("dim".to_string())]),
+            variadic: false,
+        }],
+        max_cycle_depth: Some(10),
+        doc: None,
+        body: NeuronBody::Graph {
+            context_bindings: vec![
+                Binding {
+                    name: "proj".to_string(),
+                    call_name: "Linear".to_string(),
+                    args: vec![Value::Name("dim".to_string()), Value::Name("dim".to_string())],
+                    kwargs: vec![],
+                    scope: Scope::Instance { lazy: false },
+                    frozen: false,
+                    unroll_group: None,
+                },
+                Binding {
+                    name: "adapter".to_string(),
+                    call_name: "Linear".to_string(),
+                    // "proj" here is a binding name -- should resolve to "self.proj"
+                    args: vec![Value::Name("proj".to_string()), Value::Name("dim".to_string())],
+                    kwargs: vec![],
+                    scope: Scope::Instance { lazy: true },
+                    frozen: false,
+                    unroll_group: None,
+                },
+            ],
+            context_unrolls: vec![],
+            connections: vec![
+                Connection {
+                    source: Endpoint::Ref(PortRef::new("in")),
+                    destination: Endpoint::Ref(PortRef::new("proj")),
+                },
+                Connection {
+                    source: Endpoint::Ref(PortRef::new("proj")),
+                    destination: Endpoint::Ref(PortRef::new("adapter")),
+                },
+                Connection {
+                    source: Endpoint::Ref(PortRef::new("adapter")),
+                    destination: Endpoint::Ref(PortRef::new("out")),
+                },
+            ],
+        },
+    };
+    program.neurons.insert("CrossRefLazy".to_string(), neuron);
+
+    let code = generate_pytorch(&program, "CrossRefLazy").unwrap();
+    println!("{}", code);
+
+    // Verify the eager binding is created normally
+    assert!(
+        code.contains("self.proj = Linear(dim, dim)"),
+        "proj should be eagerly instantiated in __init__"
+    );
+
+    // Verify the lazy binding placeholder
+    assert!(
+        code.contains("self._adapter = None"),
+        "adapter should have lazy placeholder in __init__"
+    );
+
+    // The key assertion: lazy instantiation must resolve "proj" to "self.proj"
+    // not emit bare "proj" which would be an unresolved variable name
+    assert!(
+        code.contains("Linear(self.proj, self.dim)"),
+        "Lazy instantiation should resolve binding names via var_names. Got:\n{}",
+        code
+    );
+
+    // Verify the lazy guard pattern
+    assert!(
+        code.contains("if self._adapter is None:"),
+        "Should have lazy guard check"
+    );
+
+    // Verify forward pass calls the lazily-instantiated module
+    assert!(
+        code.contains("self._adapter("),
+        "Forward should call the lazy module"
+    );
+}


### PR DESCRIPTION
## Summary

- Unified the two lazy instantiation codegen paths (Ref and Call) to use the same argument resolution approach
- Both paths now use `emit_lazy_instantiation()` helper and resolve args through `lazy_bindings` + `value_to_python_with_vars`
- Captured inline calls now store their info in `lazy_bindings` and `var_names` during instantiation, matching context binding behavior
- Previously the Call path used `has_captured_dimensions_impl()` for detection and resolved args independently from the Ref path

## Test plan

- [x] Added `test_lazy_binding_cross_referencing_context_bindings`: composite neuron with cross-referencing context bindings verifies generated Python resolves binding names correctly (e.g., `self.proj` not bare `proj`)
- [x] All 327 unit tests pass
- [x] All 31 integration snapshot tests pass (no snapshot changes)
- [x] Release build clean (no warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)