### PR TITLE
refactor: reduce non-test unwrap() calls (#129)

### DIFF
--- a/src/codegen/forward.rs
+++ b/src/codegen/forward.rs
@@ -50,7 +50,7 @@ fn emit_bound_module_shape_comment(
     output: &mut String,
     binding_name: &str,
     indent: &str,
-) {
+) -> std::fmt::Result {
     // Look up the neuron being called via binding_to_call_name
     if let Some(call_name) = gen.binding_to_call_name.get(binding_name).cloned() {
         if let Some(neuron_def) = gen.program.neurons.get(&call_name) {
@@ -64,13 +64,13 @@ fn emit_bound_module_shape_comment(
                         output,
                         "{}# {}() output shape: {}",
                         indent, call_name, shape_comment
-                    )
-                    .unwrap();
+                    )?;
                     gen.last_emitted_shape = Some(shape_comment);
                 }
             }
         }
     }
+    Ok(())
 }
 
 /// Generate lazy instantiation guard code for a module.
@@ -86,7 +86,7 @@ fn emit_lazy_instantiation(
     args: &[Value],
     kwargs: &[Kwarg],
     indent: &str,
-) {
+) -> std::fmt::Result {
     let args_str = args
         .iter()
         .map(|v| value_to_python_with_vars(v, &gen.var_names))
@@ -113,13 +113,13 @@ fn emit_lazy_instantiation(
         }
     };
 
-    writeln!(output, "{}if {} is None:", indent, module_ref).unwrap();
+    writeln!(output, "{}if {} is None:", indent, module_ref)?;
     writeln!(
         output,
         "{}    {} = {}({}{})",
         indent, module_ref, call_name, args_str, kwargs_str
-    )
-    .unwrap();
+    )?;
+    Ok(())
 }
 
 /// Emit a shape comment and optional assertion for a variable at a Ref destination.
@@ -130,10 +130,10 @@ fn emit_shape_comment_and_assertion(
     var_name: &str,
     node_name: &str,
     indent: &str,
-) {
+) -> std::fmt::Result {
     // Skip shape comments for unroll temp refs (they carry wrong shapes)
     if node_name.starts_with("_unroll") {
-        return;
+        return Ok(());
     }
 
     // Try to get the inferred shape for this node
@@ -144,7 +144,7 @@ fn emit_shape_comment_and_assertion(
 
             // Only emit comment if shape changed
             if gen.last_emitted_shape.as_ref() != Some(&shape_comment) {
-                writeln!(output, "{}# Expected shape: {}", indent, shape_comment).unwrap();
+                writeln!(output, "{}# Expected shape: {}", indent, shape_comment)?;
                 gen.last_emitted_shape = Some(shape_comment.clone());
             }
 
@@ -155,11 +155,12 @@ fn emit_shape_comment_and_assertion(
                         output,
                         "{}assert {}.shape == {}, f\"Shape mismatch: expected {}, got {{{}.shape}}\"",
                         indent, var_name, expected_shape, shape_comment, var_name
-                    ).unwrap();
+                    )?;
                 }
             }
         }
     }
+    Ok(())
 }
 
 /// Generate forward method body from connections
@@ -363,7 +364,7 @@ pub(super) fn generate_forward_body(
                                     "{}{} = {}.size({})",
                                     indent, safe_name, source_var, idx
                                 )
-                                .unwrap();
+                                ?;
                             }
                         }
                     }
@@ -415,7 +416,7 @@ pub(super) fn generate_forward_body(
         .cloned()
         .or(last_result)
         .unwrap_or_else(|| "x".to_string());
-    writeln!(output, "        return {}", output_var).unwrap();
+    writeln!(output, "        return {}", output_var)?;
 
     Ok(())
 }
@@ -510,13 +511,13 @@ fn process_ref(
                             "{}for _ in range({}):",
                             indent, range_expr
                         )
-                        .unwrap();
+                        ?;
                         writeln!(
                             output,
                             "{}    {} = self.__class__.{}({})",
                             indent, source_var, base_name, source_var
                         )
-                        .unwrap();
+                        ?;
                     } else {
                         // Instance: iterate over nn.ModuleList
                         writeln!(
@@ -524,13 +525,13 @@ fn process_ref(
                             "{}for {} in self.{}:",
                             indent, base_name, list_name
                         )
-                        .unwrap();
+                        ?;
                         writeln!(
                             output,
                             "{}    {} = {}({})",
                             indent, source_var, base_name, source_var
                         )
-                        .unwrap();
+                        ?;
                     }
 
                     binding_call_results
@@ -560,16 +561,16 @@ fn process_ref(
                         "{}for {} in self.{}:",
                         indent, safe_base, safe_list
                     )
-                    .unwrap();
+                    ?;
                     writeln!(
                         output,
                         "{}    {} = {}({})",
                         indent, source_var, safe_base, source_var
                     )
-                    .unwrap();
+                    ?;
 
                     // Emit shape comment once after the loop
-                    emit_bound_module_shape_comment(gen, output, &port_ref.node, indent);
+                    emit_bound_module_shape_comment(gen, output, &port_ref.node, indent)?;
 
                     // The result is the source var (mutated in-place through the loop)
                     binding_call_results
@@ -596,7 +597,7 @@ fn process_ref(
                     &lazy_args,
                     &lazy_kwargs,
                     indent,
-                );
+                )?;
             }
 
             // This is a bound module - generate a call with semantic name
@@ -605,11 +606,10 @@ fn process_ref(
                 output,
                 "{}{} = {}({})",
                 indent, result_var, module_ref, source_var
-            )
-            .unwrap();
+            )?;
 
             // Emit shape comment using the called neuron's output shape
-            emit_bound_module_shape_comment(gen, output, &port_ref.node, indent);
+            emit_bound_module_shape_comment(gen, output, &port_ref.node, indent)?;
 
             // Store the call result separately so the module reference is preserved
             // in var_names for subsequent calls (e.g., @static called N times).
@@ -625,7 +625,7 @@ fn process_ref(
 
     // Emit shape comment/assertion for intermediate nodes
     if port_ref.node != "in" && port_ref.node != "out" {
-        emit_shape_comment_and_assertion(gen, output, &source_var, &port_ref.node, indent);
+        emit_shape_comment_and_assertion(gen, output, &source_var, &port_ref.node, indent)?;
     }
 
     Ok(source_var)
@@ -657,7 +657,7 @@ fn process_tuple(
     if source_output_count == 1 && var_names.len() > 1 {
         // Implicit fork: assign source to each binding individually
         for var_name in &var_names {
-            writeln!(output, "{}{} = {}", indent, var_name, source_var).unwrap();
+            writeln!(output, "{}{} = {}", indent, var_name, source_var)?;
         }
     } else {
         // Multi-output source: standard tuple unpacking
@@ -668,7 +668,7 @@ fn process_tuple(
             var_names.join(", "),
             source_var
         )
-        .unwrap();
+        ?;
     }
     Ok(source_var) // Return tuple as result
 }
@@ -710,7 +710,7 @@ fn process_call(
             &lazy_args,
             &lazy_kwargs,
             indent,
-        );
+        )?;
 
         // Mark as primitive for imports
         if let Some(neuron) = gen.program.neurons.get(call_name.as_str()) {
@@ -727,7 +727,7 @@ fn process_call(
             "{}{} = self._{}({})",
             indent, result_var, module_name, source_var
         )
-        .unwrap();
+        ?;
     } else {
         // Normal call to pre-instantiated module
         writeln!(
@@ -735,7 +735,7 @@ fn process_call(
             "{}{} = self.{}({})",
             indent, result_var, module_name, source_var
         )
-        .unwrap();
+        ?;
     }
 
     // Emit shape comment/assertion for the call result
@@ -752,7 +752,7 @@ fn process_call(
                     "{}# {}() output shape: {}",
                     indent, name, shape_comment
                 )
-                .unwrap();
+                ?;
                 gen.last_emitted_shape = Some(shape_comment.clone());
             }
 
@@ -762,7 +762,7 @@ fn process_call(
                         output,
                         "{}assert {}.shape == {}, f\"{}() shape mismatch: expected {}, got {{{}.shape}}\"",
                         indent, result_var, expected_shape, name, shape_comment, result_var
-                    ).unwrap();
+                    )?;
                 }
             }
         }
@@ -791,7 +791,7 @@ fn process_match(
     let result_var = make_var_name(used_var_names, "match_out");
 
     // Initialize result_var to None for safety (though not strictly needed if all paths return)
-    writeln!(output, "{}{} = None", indent, result_var).unwrap();
+    writeln!(output, "{}{} = None", indent, result_var)?;
 
     let mut first = true;
     let mut prev_condition = String::new();
@@ -840,9 +840,9 @@ fn process_match(
 
         // Only output condition if it's not "else"
         if prefix == "else" {
-            writeln!(output, "{}{}:", indent, prefix).unwrap();
+            writeln!(output, "{}{}:", indent, prefix)?;
         } else {
-            writeln!(output, "{}{} {}:", indent, prefix, shape_check.condition).unwrap();
+            writeln!(output, "{}{} {}:", indent, prefix, shape_check.condition)?;
             prev_condition = shape_check.condition.clone();
         }
 
@@ -852,12 +852,12 @@ fn process_match(
 
         // Emit dimension bindings before processing pipeline
         for binding in &shape_check.bindings {
-            writeln!(output, "{}{}", arm_indent, binding).unwrap();
+            writeln!(output, "{}{}", arm_indent, binding)?;
         }
 
         // If guard uses captured dimensions, check it after binding
         let pipeline_indent = if let Some(guard_cond) = &shape_check.guard_condition {
-            writeln!(output, "{}if {}:", arm_indent, guard_cond).unwrap();
+            writeln!(output, "{}if {}:", arm_indent, guard_cond)?;
             format!("{}    ", arm_indent)
         } else {
             arm_indent.clone()
@@ -913,7 +913,7 @@ fn process_match(
             "{}{} = {}",
             pipeline_indent, result_var, current_var
         )
-        .unwrap();
+        ?;
 
         // Restore var_names to prevent match arm scope from leaking
         gen.var_names = saved_var_names;
@@ -921,13 +921,13 @@ fn process_match(
 
     // Else clause: only raise if no reachable catch-all exists
     if !has_reachable_catchall {
-        writeln!(output, "{}else:", indent).unwrap();
+        writeln!(output, "{}else:", indent)?;
         writeln!(
             output,
             "{}    raise ValueError(f'No match found for shape {{ {}.shape }}')",
             indent, source_var
         )
-        .unwrap();
+        ?;
     }
 
     Ok(result_var)
@@ -1013,7 +1013,7 @@ fn process_if(
     let result_var = make_var_name(used_var_names, "cond_out");
 
     // Initialize result variable to None
-    writeln!(output, "{}{} = None", indent, result_var).unwrap();
+    writeln!(output, "{}{} = None", indent, result_var)?;
 
     // Handle branches
     for (i, branch) in if_expr.branches.iter().enumerate() {
@@ -1021,7 +1021,7 @@ fn process_if(
         // Ensure self.param is used in conditions
         let cond_str = gen.value_to_python_dim(&branch.condition);
 
-        writeln!(output, "{}{} {}:", indent, prefix, cond_str).unwrap();
+        writeln!(output, "{}{} {}:", indent, prefix, cond_str)?;
         let branch_indent = format!("{}    ", indent);
 
         // Process pipeline
@@ -1032,13 +1032,13 @@ fn process_if(
             binding_call_results, emitted_unroll_groups,
         )?;
 
-        writeln!(output, "{}{} = {}", branch_indent, result_var, current_var).unwrap();
+        writeln!(output, "{}{} = {}", branch_indent, result_var, current_var)?;
         gen.var_names = saved_var_names;
     }
 
     // Else branch
     if let Some(else_branch) = &if_expr.else_branch {
-        writeln!(output, "{}else:", indent).unwrap();
+        writeln!(output, "{}else:", indent)?;
         let branch_indent = format!("{}    ", indent);
         let saved_var_names = gen.var_names.clone();
         let current_var = process_branch_pipeline(
@@ -1046,12 +1046,12 @@ fn process_if(
             used_var_names, call_to_result, match_to_result, if_to_result,
             binding_call_results, emitted_unroll_groups,
         )?;
-        writeln!(output, "{}{} = {}", branch_indent, result_var, current_var).unwrap();
+        writeln!(output, "{}{} = {}", branch_indent, result_var, current_var)?;
         gen.var_names = saved_var_names;
     } else {
         // Implicit else: pass-through/Identity
-        writeln!(output, "{}else:", indent).unwrap();
-        writeln!(output, "{}    {} = {}", indent, result_var, source_var).unwrap();
+        writeln!(output, "{}else:", indent)?;
+        writeln!(output, "{}    {} = {}", indent, result_var, source_var)?;
     }
 
     Ok(result_var)
@@ -1079,7 +1079,7 @@ fn process_reshape(
     for dim in &reshape.dims {
         if let ReshapeDim::Binding { name, expr } = dim {
             let expr_str = gen.value_to_python_dim(expr);
-            writeln!(output, "{}{} = {}", indent, sanitize_python_ident(name), expr_str).unwrap();
+            writeln!(output, "{}{} = {}", indent, sanitize_python_ident(name), expr_str)?;
         }
     }
 
@@ -1123,7 +1123,7 @@ fn process_reshape_bare(
         "{}{} = {}.reshape({})",
         indent, result_var, source_var, shape_args
     )
-    .unwrap();
+    ?;
     Ok(())
 }
 
@@ -1214,7 +1214,7 @@ fn process_reshape_reduce(
                     "{}{} = {}.{}(dim={})",
                     indent, result_var, source_var, method, reduce_dims[0]
                 )
-                .unwrap();
+                ?;
             } else {
                 let dims_str = reduce_dims
                     .iter()
@@ -1226,7 +1226,7 @@ fn process_reshape_reduce(
                     "{}{} = {}.{}(dim=({}))",
                     indent, result_var, source_var, method, dims_str
                 )
-                .unwrap();
+                ?;
             }
         }
         TransformStrategy::Neuron { .. } => {
@@ -1236,7 +1236,7 @@ fn process_reshape_reduce(
                 "{}{} = {}({})",
                 indent, result_var, module_name, source_var
             )
-            .unwrap();
+            ?;
         }
     }
     Ok(())
@@ -1318,7 +1318,7 @@ fn process_reshape_repeat(
                     current,
                     idx + offset // Account for previous unsqueezes shifting indices
                 )
-                .unwrap();
+                ?;
                 current = unsqueezed;
             }
 
@@ -1335,7 +1335,7 @@ fn process_reshape_repeat(
                 "{}{} = {}.expand({})",
                 indent, result_var, current, shape_args
             )
-            .unwrap();
+            ?;
         }
         TransformStrategy::Neuron { .. } => {
             let module_name = format!("self._transform_{}", reshape.id);
@@ -1344,7 +1344,7 @@ fn process_reshape_repeat(
                 "{}{} = {}({})",
                 indent, result_var, module_name, source_var
             )
-            .unwrap();
+            ?;
         }
         _ => {
             // Validator rejects unknown intrinsics, so this is unreachable

--- a/src/codegen/generator.rs
+++ b/src/codegen/generator.rs
@@ -20,6 +20,8 @@ pub enum CodegenError {
     InvalidConnection(String),
     #[error("Unsupported feature: {0}")]
     UnsupportedFeature(String),
+    #[error("Format error: {0}")]
+    FormatError(#[from] std::fmt::Error),
 }
 
 /// Result of shape check generation containing condition and dimension bindings
@@ -224,12 +226,12 @@ impl<'a> CodeGenerator<'a> {
         let mut output = String::new();
 
         // Generate class definition
-        writeln!(output, "class {}(nn.Module):", sanitize_python_ident(&neuron.name)).unwrap();
+        writeln!(output, "class {}(nn.Module):", sanitize_python_ident(&neuron.name))?;
 
         // Generate __init__
         self.generate_init(&mut output, neuron)?;
 
-        writeln!(output).unwrap();
+        writeln!(output)?;
 
         // Generate forward
         self.generate_forward(&mut output, neuron)?;
@@ -262,19 +264,19 @@ impl<'a> CodeGenerator<'a> {
             format!("self, {}", param_strs.join(", "))
         };
 
-        writeln!(output, "    def __init__({}):", params).unwrap();
-        writeln!(output, "        super().__init__()").unwrap();
+        writeln!(output, "    def __init__({}):", params)?;
+        writeln!(output, "        super().__init__()")?;
 
         // Store parameters as instance variables (needed for guards)
         for param in &neuron.params {
             let safe_name = sanitize_python_ident(&param.name);
-            writeln!(output, "        self.{} = {}", safe_name, safe_name).unwrap();
+            writeln!(output, "        self.{} = {}", safe_name, safe_name)?;
         }
 
         match &neuron.body {
             NeuronBody::Primitive(_) => {
                 // Primitives don't instantiate sub-modules
-                writeln!(output, "        pass").unwrap();
+                writeln!(output, "        pass")?;
             }
             NeuronBody::Graph {
                 context_bindings,
@@ -315,7 +317,7 @@ impl<'a> CodeGenerator<'a> {
                 .join(", ")
         };
 
-        writeln!(output, "    def forward(self, {}):", input_params).unwrap();
+        writeln!(output, "    def forward(self, {}):", input_params)?;
 
         // Register all params in var_names with self. prefix so that lazy
         // instantiation can resolve them (e.g., dim → self.dim, layer → self.layer).
@@ -332,7 +334,7 @@ impl<'a> CodeGenerator<'a> {
         match &neuron.body {
             NeuronBody::Primitive(_impl_ref) => {
                 // Primitive neurons just pass through
-                writeln!(output, "        return {}", input_params).unwrap();
+                writeln!(output, "        return {}", input_params)?;
             }
             NeuronBody::Graph { connections, .. } => {
                 forward::generate_forward_body(
@@ -500,11 +502,10 @@ pub fn generate_pytorch_with_options(
             "{} = {}",
             sanitize_python_ident(&global.name),
             dummy_gen.value_to_python(&global.value)
-        )
-        .unwrap();
+        )?;
     }
     if !program.globals.is_empty() {
-        writeln!(globals_output).unwrap();
+        writeln!(globals_output)?;
     }
 
     // Generate code for all dependencies in order
@@ -512,7 +513,8 @@ pub fn generate_pytorch_with_options(
     let mut all_primitives = HashSet::new();
 
     for dep_name in &dependencies {
-        let neuron = program.neurons.get(dep_name).unwrap(); // Safe because we just collected it
+        let neuron = program.neurons.get(dep_name)
+            .expect("dependency was just collected from program"); // Safe: collected above
 
         // Run shape inference for this neuron
         let inference_ctx = run_shape_inference_for_neuron(neuron, program);
@@ -535,32 +537,32 @@ pub fn generate_pytorch_with_options(
     if options.bundle {
         // Bundle mode: emit a unified import block (superset of what all primitive
         // files use) then inline only the class definitions that are needed.
-        writeln!(imports_output, "import math").unwrap();
-        writeln!(imports_output, "from typing import List, Optional, Tuple, Union").unwrap();
-        writeln!(imports_output, "import torch").unwrap();
-        writeln!(imports_output, "import torch.nn as nn").unwrap();
-        writeln!(imports_output, "import torch.nn.functional as F").unwrap();
-        writeln!(imports_output).unwrap();
+        writeln!(imports_output, "import math")?;
+        writeln!(imports_output, "from typing import List, Optional, Tuple, Union")?;
+        writeln!(imports_output, "import torch")?;
+        writeln!(imports_output, "import torch.nn as nn")?;
+        writeln!(imports_output, "import torch.nn.functional as F")?;
+        writeln!(imports_output)?;
 
         // Inline only the needed primitive modules
         let modules = registry.modules_for_primitives(&primitives);
         for module_path in &modules {
             if let Some(source) = embedded_source_for_module(module_path) {
-                writeln!(imports_output, "# --- inlined from {} ---\n", module_path).unwrap();
+                writeln!(imports_output, "# --- inlined from {} ---\n", module_path)?;
                 imports_output.push_str(&strip_preamble(source));
-                writeln!(imports_output).unwrap();
+                writeln!(imports_output)?;
             }
         }
     } else {
         // Normal mode: generate import statements
-        writeln!(imports_output, "import torch").unwrap();
-        writeln!(imports_output, "import torch.nn as nn").unwrap();
+        writeln!(imports_output, "import torch")?;
+        writeln!(imports_output, "import torch.nn as nn")?;
 
         let imports = registry.generate_imports(&primitives);
         for import in imports {
-            writeln!(imports_output, "{}", import).unwrap();
+            writeln!(imports_output, "{}", import)?;
         }
-        writeln!(imports_output).unwrap();
+        writeln!(imports_output)?;
     }
 
     // Combine imports, globals and all neuron code

--- a/src/codegen/instantiation.rs
+++ b/src/codegen/instantiation.rs
@@ -74,7 +74,7 @@ pub(super) fn generate_module_instantiations(
                 Scope::Instance { lazy: false } => {
                     if args.is_empty() && kwargs.is_empty() {
                         // Pass-through: the param is already an nn.Module instance
-                        writeln!(output, "        self.{} = {}", module_name, name).unwrap();
+                        writeln!(output, "        self.{} = {}", module_name, name)?;
                     } else {
                         // Construct from type: the param is a class reference
                         let (args_str, kwargs_str) = extract_kwargs(args, kwargs);
@@ -83,7 +83,7 @@ pub(super) fn generate_module_instantiations(
                             "        self.{} = {}({}{})",
                             module_name, name, args_str, kwargs_str
                         )
-                        .unwrap();
+                        ?;
                     }
                     gen.var_names
                         .insert(module_name.clone(), format!("self.{}", module_name));
@@ -92,7 +92,7 @@ pub(super) fn generate_module_instantiations(
                 _ => {
                     // Lazy or other scopes: store the param reference as a submodule.
                     // This allows higher-order neurons to forward the passed-in module.
-                    writeln!(output, "        self.{} = {}", module_name, name).unwrap();
+                    writeln!(output, "        self.{} = {}", module_name, name)?;
                     gen.var_names
                         .insert(module_name.clone(), format!("self.{}", module_name));
                     instantiated_count += 1;
@@ -123,11 +123,11 @@ pub(super) fn generate_module_instantiations(
                 })
                 .collect();
 
-            writeln!(output, "        self.{} = nn.Sequential(", module_name).unwrap();
+            writeln!(output, "        self.{} = nn.Sequential(", module_name)?;
             for item in &items {
-                writeln!(output, "            {},", item).unwrap();
+                writeln!(output, "            {},", item)?;
             }
-            writeln!(output, "        )").unwrap();
+            writeln!(output, "        )")?;
 
             // Track primitives used in the sequential
             for arg in args {
@@ -168,13 +168,13 @@ pub(super) fn generate_module_instantiations(
                     "        if not hasattr(self.__class__, '{}'):",
                     module_name
                 )
-                .unwrap();
+                ?;
                 writeln!(
                     output,
                     "            self.__class__.{} = {}({}{})",
                     module_name, name, args_str, kwargs_str
                 )
-                .unwrap();
+                ?;
 
                 gen.var_names.insert(
                     module_name.clone(),
@@ -188,7 +188,7 @@ pub(super) fn generate_module_instantiations(
                     "        self._{} = None  # Lazy instantiation (@lazy)",
                     module_name
                 )
-                .unwrap();
+                ?;
 
                 gen.lazy_bindings.insert(
                     module_name.clone(),
@@ -206,7 +206,7 @@ pub(super) fn generate_module_instantiations(
                     "        self.{} = {}({}{})",
                     module_name, name, args_str, kwargs_str
                 )
-                .unwrap();
+                ?;
 
                 gen.var_names
                     .insert(module_name.clone(), format!("self.{}", module_name));
@@ -253,13 +253,13 @@ pub(super) fn generate_module_instantiations(
                 "        if not hasattr(self.__class__, '{}'):",
                 base_name
             )
-            .unwrap();
+            ?;
             writeln!(
                 output,
                 "            self.__class__.{} = {}({}{})",
                 base_name, call_name, args_str, kwargs_str
             )
-            .unwrap();
+            ?;
 
             // Register the class-level var name for the base binding
             gen.var_names.insert(
@@ -277,14 +277,14 @@ pub(super) fn generate_module_instantiations(
                 "        self.{} = nn.ModuleList([",
                 list_name
             )
-            .unwrap();
+            ?;
             writeln!(
                 output,
                 "            {}({}{}) for _ in range({})",
                 call_name, args_str, kwargs_str, range_expr
             )
-            .unwrap();
-            writeln!(output, "        ])").unwrap();
+            ?;
+            writeln!(output, "        ])")?;
 
             // Register the ModuleList var name
             gen.var_names
@@ -342,7 +342,7 @@ pub(super) fn generate_module_instantiations(
                 "        self._{} = None  # Lazy instantiation (captured)",
                 module_name
             )
-            .unwrap();
+            ?;
 
             gen.lazy_bindings.insert(
                 module_name.clone(),
@@ -369,16 +369,16 @@ pub(super) fn generate_module_instantiations(
             "        self.{} = {}({}{})",
             module_name, name, args_str, kwargs_str
         )
-        .unwrap();
+        ?;
         instantiated_count += 1;
     }
 
     // 4. Collect and instantiate neuron-based transform strategies from Reshape endpoints
     let mut seen_transforms: HashSet<usize> = HashSet::new();
-    collect_reshape_transforms(connections, &mut seen_transforms, gen, output, &mut instantiated_count);
+    collect_reshape_transforms(connections, &mut seen_transforms, gen, output, &mut instantiated_count)?;
 
     if instantiated_count == 0 {
-        writeln!(output, "        pass").unwrap();
+        writeln!(output, "        pass")?;
     }
 
     Ok(())
@@ -391,11 +391,12 @@ fn collect_reshape_transforms(
     gen: &mut CodeGenerator,
     output: &mut String,
     instantiated_count: &mut usize,
-) {
+) -> std::fmt::Result {
     for conn in connections {
-        collect_reshape_transforms_from_endpoint(&conn.source, seen, gen, output, instantiated_count);
-        collect_reshape_transforms_from_endpoint(&conn.destination, seen, gen, output, instantiated_count);
+        collect_reshape_transforms_from_endpoint(&conn.source, seen, gen, output, instantiated_count)?;
+        collect_reshape_transforms_from_endpoint(&conn.destination, seen, gen, output, instantiated_count)?;
     }
+    Ok(())
 }
 
 fn collect_reshape_transforms_from_endpoint(
@@ -404,11 +405,11 @@ fn collect_reshape_transforms_from_endpoint(
     gen: &mut CodeGenerator,
     output: &mut String,
     instantiated_count: &mut usize,
-) {
+) -> std::fmt::Result {
     match endpoint {
         Endpoint::Reshape(reshape) => {
             if seen.contains(&reshape.id) {
-                return;
+                return Ok(());
             }
             if let Some(ref annotation) = reshape.annotation {
                 let strategy = match annotation {
@@ -436,7 +437,7 @@ fn collect_reshape_transforms_from_endpoint(
                         "        self.{} = {}({}{})",
                         module_name, name, args_str, kwargs_str
                     )
-                    .unwrap();
+                    ?;
                     *instantiated_count += 1;
                 }
             }
@@ -444,24 +445,25 @@ fn collect_reshape_transforms_from_endpoint(
         Endpoint::Match(match_expr) => {
             for arm in &match_expr.arms {
                 for ep in &arm.pipeline {
-                    collect_reshape_transforms_from_endpoint(ep, seen, gen, output, instantiated_count);
+                    collect_reshape_transforms_from_endpoint(ep, seen, gen, output, instantiated_count)?;
                 }
             }
         }
         Endpoint::If(if_expr) => {
             for branch in &if_expr.branches {
                 for ep in &branch.pipeline {
-                    collect_reshape_transforms_from_endpoint(ep, seen, gen, output, instantiated_count);
+                    collect_reshape_transforms_from_endpoint(ep, seen, gen, output, instantiated_count)?;
                 }
             }
             if let Some(else_branch) = &if_expr.else_branch {
                 for ep in else_branch {
-                    collect_reshape_transforms_from_endpoint(ep, seen, gen, output, instantiated_count);
+                    collect_reshape_transforms_from_endpoint(ep, seen, gen, output, instantiated_count)?;
                 }
             }
         }
         _ => {}
     }
+    Ok(())
 }
 
 fn extract_kwargs(args: &[Value], kwargs: &[(String, Value)]) -> (String, String) {

--- a/src/codegen/utils.rs
+++ b/src/codegen/utils.rs
@@ -213,7 +213,7 @@ pub(super) fn snake_case_impl(name: &str) -> String {
             if !result.is_empty() && (!prev_upper || next_lower) {
                 result.push('_');
             }
-            result.push(c.to_lowercase().next().unwrap());
+            result.push(c.to_lowercase().next().expect("uppercase char always has lowercase"));
         } else {
             result.push(c);
         }

--- a/src/grammar/ast.rs
+++ b/src/grammar/ast.rs
@@ -3,13 +3,13 @@
 //! Converts pest parse trees (Pair<Rule>) into NeuroScript IR types.
 //! Handles indentation validation during the conversion.
 //!
-//! # Safety of `.unwrap()` calls
+//! # Safety of `.expect()` calls
 //!
-//! This module contains many `.unwrap()` calls on `inner.next()` (pest `Pairs` iterators).
-//! These are safe because the PEG grammar (`neuroscript.pest`) guarantees the required
-//! children exist — pest will not produce a successful parse tree missing mandatory
-//! sub-rules. Each `unwrap()` corresponds to a mandatory child in the grammar rule
-//! being destructured.
+//! This module contains many `.expect("guaranteed by grammar")` calls on `inner.next()`
+//! (pest `Pairs` iterators). These are safe because the PEG grammar (`neuroscript.pest`)
+//! guarantees the required children exist — pest will not produce a successful parse tree
+//! missing mandatory sub-rules. Each `.expect()` corresponds to a mandatory child in the
+//! grammar rule being destructured.
 
 use miette::SourceSpan;
 use pest::iterators::Pair;
@@ -100,7 +100,7 @@ impl AstBuilder {
         inner.next(); // Skip at
         inner.next(); // Skip keyword_global
 
-        let content = inner.next().unwrap();
+        let content = inner.next().expect("guaranteed by grammar");
         match content.as_rule() {
             Rule::binding => {
                 let binding = self.build_binding(content)?;
@@ -116,9 +116,9 @@ impl AstBuilder {
             }
             Rule::global_value_binding => {
                 let mut v_inner = content.into_inner();
-                let name = self.extract_ident(v_inner.next().unwrap())?;
+                let name = self.extract_ident(v_inner.next().expect("guaranteed by grammar"))?;
                 v_inner.next(); // Skip assign
-                let value = self.build_value(v_inner.next().unwrap())?;
+                let value = self.build_value(v_inner.next().expect("guaranteed by grammar"))?;
                 Ok(GlobalBinding { name, value })
             }
             _ => unreachable!(),
@@ -135,13 +135,13 @@ impl AstBuilder {
         inner.next();
 
         // Get source identifier
-        let source = self.extract_ident(inner.next().unwrap())?;
+        let source = self.extract_ident(inner.next().expect("guaranteed by grammar"))?;
 
         // Skip comma
         inner.next();
 
         // Get path
-        let path_pair = inner.next().unwrap();
+        let path_pair = inner.next().expect("guaranteed by grammar");
         let path = self.build_impl_path(path_pair)?;
 
         Ok(UseStmt { source, path })
@@ -197,7 +197,7 @@ impl AstBuilder {
         }
 
         // Get name
-        let name = self.extract_ident(next.unwrap())?;
+        let name = self.extract_ident(next.expect("guaranteed by grammar"))?;
 
         // Check for params (optional)
         let mut params = vec![];
@@ -277,7 +277,7 @@ impl AstBuilder {
     ) -> Result<(), ParseError> {
         debug_assert_eq!(pair.as_rule(), Rule::neuron_section);
 
-        let section = pair.into_inner().next().unwrap();
+        let section = pair.into_inner().next().expect("guaranteed by grammar");
 
         match section.as_rule() {
             Rule::in_section => {
@@ -326,7 +326,7 @@ impl AstBuilder {
         debug_assert_eq!(pair.as_rule(), Rule::param);
 
         let mut inner = pair.into_inner();
-        let name = self.extract_ident(inner.next().unwrap())?;
+        let name = self.extract_ident(inner.next().expect("guaranteed by grammar"))?;
 
         let mut default = None;
         let mut type_annotation = None;
@@ -408,12 +408,12 @@ impl AstBuilder {
         debug_assert_eq!(pair.as_rule(), Rule::port_def);
 
         let mut inner = pair.into_inner();
-        let name = self.extract_ident(inner.next().unwrap())?;
+        let name = self.extract_ident(inner.next().expect("guaranteed by grammar"))?;
 
         // Skip colon
         inner.next();
 
-        let shape = self.build_shape(inner.next().unwrap())?;
+        let shape = self.build_shape(inner.next().expect("guaranteed by grammar"))?;
 
         Ok(Port { name, shape, variadic: false })
     }
@@ -492,7 +492,7 @@ impl AstBuilder {
                 // Skip '@', 'global'
                 inner.next();
                 inner.next();
-                let ident = inner.next().unwrap().as_str().to_string();
+                let ident = inner.next().expect("guaranteed by grammar").as_str().to_string();
                 Ok(Dim::Global(ident))
             }
             Rule::dim => self.build_dim(first.clone()),
@@ -504,7 +504,7 @@ impl AstBuilder {
     fn build_dim_op(&mut self, pair: Pair<Rule>) -> Result<BinOp, ParseError> {
         debug_assert_eq!(pair.as_rule(), Rule::dim_op);
 
-        let inner = pair.into_inner().next().unwrap();
+        let inner = pair.into_inner().next().expect("guaranteed by grammar");
 
         match inner.as_rule() {
             Rule::plus => Ok(BinOp::Add),
@@ -561,12 +561,12 @@ impl AstBuilder {
         let mut inner = pair.into_inner();
 
         // Parse: ident = unroll(count):
-        let aggregate_name = inner.next().unwrap().as_str().to_string(); // ident
+        let aggregate_name = inner.next().expect("guaranteed by grammar").as_str().to_string(); // ident
         inner.next(); // Skip assign (=)
         inner.next(); // Skip keyword_unroll
         inner.next(); // Skip lparen
 
-        let count = self.build_value(inner.next().unwrap())?;
+        let count = self.build_value(inner.next().expect("guaranteed by grammar"))?;
 
         // Skip rparen, colon
         inner.next();
@@ -612,13 +612,13 @@ impl AstBuilder {
             SourceSpan::new(pest_span.start().into(), pest_span.end() - pest_span.start());
 
         let mut inner = pair.into_inner();
-        let mut first = inner.next().unwrap();
+        let mut first = inner.next().expect("guaranteed by grammar");
         let mut scope = crate::interfaces::Scope::Instance { lazy: false };
 
         // Check for annotation
         if first.as_rule() == Rule::binding_annotation {
             scope = self.build_binding_annotation(first)?;
-            first = inner.next().unwrap(); // Move to binding
+            first = inner.next().expect("guaranteed by grammar"); // Move to binding
         }
 
         // Build the binding
@@ -639,7 +639,7 @@ impl AstBuilder {
         let mut inner = pair.into_inner();
         inner.next(); // Skip 'at'
 
-        let keyword = inner.next().unwrap();
+        let keyword = inner.next().expect("guaranteed by grammar");
         match keyword.as_rule() {
             Rule::keyword_static => Ok(crate::interfaces::Scope::Static),
             Rule::keyword_global => Ok(crate::interfaces::Scope::Global),
@@ -653,12 +653,12 @@ impl AstBuilder {
         debug_assert_eq!(pair.as_rule(), Rule::binding);
 
         let mut inner = pair.into_inner();
-        let name = self.extract_ident(inner.next().unwrap())?;
+        let name = self.extract_ident(inner.next().expect("guaranteed by grammar"))?;
 
         // Skip assign
         inner.next();
 
-        let neuron_expr = inner.next().unwrap();
+        let neuron_expr = inner.next().expect("guaranteed by grammar");
         let (call_name, args, kwargs, frozen) = self.build_neuron_expr(neuron_expr)?;
 
         Ok(Binding {
@@ -681,7 +681,7 @@ impl AstBuilder {
     ) -> Result<(String, Vec<Value>, Vec<Kwarg>, bool), ParseError> {
         debug_assert_eq!(pair.as_rule(), Rule::neuron_expr);
 
-        let inner = pair.into_inner().next().unwrap();
+        let inner = pair.into_inner().next().expect("guaranteed by grammar");
         match inner.as_rule() {
             Rule::call_expr => {
                 let (name, args, kwargs) = self.build_call_expr(inner)?;
@@ -704,7 +704,7 @@ impl AstBuilder {
                 let mut f_inner = inner.into_inner();
                 f_inner.next(); // Skip keyword_freeze
                 f_inner.next(); // Skip lparen
-                let sub_expr = f_inner.next().unwrap();
+                let sub_expr = f_inner.next().expect("guaranteed by grammar");
                 let (sub_name, sub_args, sub_kwargs, _) = self.build_neuron_expr(sub_expr)?;
 
                 // Wrap in Freeze call
@@ -728,7 +728,7 @@ impl AstBuilder {
         debug_assert_eq!(pair.as_rule(), Rule::call_expr);
 
         let mut inner = pair.into_inner();
-        let name = self.extract_ident(inner.next().unwrap())?;
+        let name = self.extract_ident(inner.next().expect("guaranteed by grammar"))?;
 
         let mut args = vec![];
         let mut kwargs = vec![];
@@ -773,12 +773,12 @@ impl AstBuilder {
         debug_assert_eq!(pair.as_rule(), Rule::kwarg);
 
         let mut inner = pair.into_inner();
-        let name = self.extract_ident(inner.next().unwrap())?;
+        let name = self.extract_ident(inner.next().expect("guaranteed by grammar"))?;
 
         // Skip assign
         inner.next();
 
-        let value = self.build_value(inner.next().unwrap())?;
+        let value = self.build_value(inner.next().expect("guaranteed by grammar"))?;
 
         Ok((name, value))
     }
@@ -801,7 +801,7 @@ impl AstBuilder {
         debug_assert_eq!(pair.as_rule(), Rule::impl_ref);
 
         let mut inner = pair.into_inner();
-        let first = inner.next().unwrap();
+        let first = inner.next().expect("guaranteed by grammar");
 
         match first.as_rule() {
             Rule::keyword_external => {
@@ -827,7 +827,7 @@ impl AstBuilder {
                 // Skip comma
                 inner.next();
 
-                let path_pair = inner.next().unwrap();
+                let path_pair = inner.next().expect("guaranteed by grammar");
                 let path_parts = self.build_impl_path(path_pair)?;
 
                 Ok(ImplRef::Source {
@@ -862,14 +862,14 @@ impl AstBuilder {
         let mut inner = pair.into_inner();
 
         // First endpoint
-        let first_endpoint = self.build_endpoint(inner.next().unwrap())?;
+        let first_endpoint = self.build_endpoint(inner.next().expect("guaranteed by grammar"))?;
 
         // Second pair is either arrow (for connection_tail) or fat_arrow_step
-        let second = inner.next().unwrap();
+        let second = inner.next().expect("guaranteed by grammar");
         match second.as_rule() {
             Rule::arrow => {
                 // connection_tail
-                let tail = inner.next().unwrap();
+                let tail = inner.next().expect("guaranteed by grammar");
                 self.build_connection_tail(first_endpoint, tail)
             }
             Rule::fat_arrow_step => {
@@ -1028,7 +1028,7 @@ impl AstBuilder {
     fn build_endpoint(&mut self, pair: Pair<Rule>) -> Result<Endpoint, ParseError> {
         debug_assert_eq!(pair.as_rule(), Rule::endpoint);
 
-        let inner = pair.into_inner().next().unwrap();
+        let inner = pair.into_inner().next().expect("guaranteed by grammar");
 
         match inner.as_rule() {
             Rule::match_eval_expr => Ok(Endpoint::Match(self.build_match_eval_expr(inner)?)),
@@ -1053,9 +1053,9 @@ impl AstBuilder {
 
         // if condition : pipeline
         inner.next(); // Skip 'if'
-        let condition = self.build_value(inner.next().unwrap())?;
+        let condition = self.build_value(inner.next().expect("guaranteed by grammar"))?;
         inner.next(); // Skip ':'
-        let pipeline = self.build_branch_pipeline(inner.next().unwrap())?;
+        let pipeline = self.build_branch_pipeline(inner.next().expect("guaranteed by grammar"))?;
         branches.push(crate::interfaces::IfBranch {
             condition,
             pipeline,
@@ -1065,9 +1065,9 @@ impl AstBuilder {
         while let Some(token) = inner.next() {
             match token.as_rule() {
                 Rule::keyword_elif => {
-                    let condition = self.build_value(inner.next().unwrap())?;
+                    let condition = self.build_value(inner.next().expect("guaranteed by grammar"))?;
                     inner.next(); // Skip ':'
-                    let pipeline = self.build_branch_pipeline(inner.next().unwrap())?;
+                    let pipeline = self.build_branch_pipeline(inner.next().expect("guaranteed by grammar"))?;
                     branches.push(crate::interfaces::IfBranch {
                         condition,
                         pipeline,
@@ -1075,7 +1075,7 @@ impl AstBuilder {
                 }
                 Rule::keyword_else => {
                     inner.next(); // Skip ':'
-                    else_branch = Some(self.build_branch_pipeline(inner.next().unwrap())?);
+                    else_branch = Some(self.build_branch_pipeline(inner.next().expect("guaranteed by grammar"))?);
                 }
                 Rule::NEWLINE => continue,
                 _ => break,
@@ -1093,7 +1093,7 @@ impl AstBuilder {
     fn build_branch_pipeline(&mut self, pair: Pair<Rule>) -> Result<Vec<Endpoint>, ParseError> {
         debug_assert_eq!(pair.as_rule(), Rule::branch_pipeline);
 
-        let inner = pair.clone().into_inner().next().unwrap();
+        let inner = pair.clone().into_inner().next().expect("guaranteed by grammar");
         match inner.as_rule() {
             Rule::indented_pipeline => {
                 // We're already in a pipeline structure, but we need a starting endpoint for the indented pipeline logic
@@ -1299,7 +1299,7 @@ impl AstBuilder {
         debug_assert_eq!(pair.as_rule(), Rule::ref_endpoint);
 
         let mut inner = pair.into_inner();
-        let first = inner.next().unwrap();
+        let first = inner.next().expect("guaranteed by grammar");
 
         let node = match first.as_rule() {
             Rule::keyword_in => "in".to_string(),
@@ -1331,7 +1331,7 @@ impl AstBuilder {
         debug_assert_eq!(pair.as_rule(), Rule::call_endpoint);
 
         let mut inner = pair.into_inner();
-        let first = inner.next().unwrap();
+        let first = inner.next().expect("guaranteed by grammar");
 
         let (name, args, kwargs, frozen) = match first.as_rule() {
             Rule::call_expr => {
@@ -1340,7 +1340,7 @@ impl AstBuilder {
             }
             Rule::keyword_freeze => {
                 inner.next(); // Skip lparen
-                let sub_expr = inner.next().unwrap();
+                let sub_expr = inner.next().expect("guaranteed by grammar");
                 let (sub_name, sub_args, sub_kwargs, _) = self.build_neuron_expr(sub_expr)?;
 
                 (
@@ -1411,7 +1411,7 @@ impl AstBuilder {
         inner.next(); // lparen
 
         // Extract subject name from value
-        let subject_value = inner.next().unwrap();
+        let subject_value = inner.next().expect("guaranteed by grammar");
         let subject_name = match self.build_value(subject_value)? {
             Value::Name(name) => name,
             other => {
@@ -1450,7 +1450,7 @@ impl AstBuilder {
         let mut inner = pair.into_inner();
 
         // Parse port contract
-        let contract = self.build_neuron_port_contract(inner.next().unwrap())?;
+        let contract = self.build_neuron_port_contract(inner.next().expect("guaranteed by grammar"))?;
 
         // Optional guard and pipeline
         let mut guard = None;
@@ -1487,10 +1487,10 @@ impl AstBuilder {
 
         // Parse input: keyword_in, optional ident, shape
         inner.next(); // keyword_in
-        let mut next = inner.next().unwrap();
+        let mut next = inner.next().expect("guaranteed by grammar");
         let in_name = if next.as_rule() == Rule::ident {
             let name = next.as_str().to_string();
-            next = inner.next().unwrap(); // advance to shape
+            next = inner.next().expect("guaranteed by grammar"); // advance to shape
             name
         } else {
             "default".to_string()
@@ -1502,10 +1502,10 @@ impl AstBuilder {
 
         // Parse output: keyword_out, optional ident, shape
         inner.next(); // keyword_out
-        let mut next = inner.next().unwrap();
+        let mut next = inner.next().expect("guaranteed by grammar");
         let out_name = if next.as_rule() == Rule::ident {
             let name = next.as_str().to_string();
-            next = inner.next().unwrap(); // advance to shape
+            next = inner.next().expect("guaranteed by grammar"); // advance to shape
             name
         } else {
             "default".to_string()
@@ -1525,7 +1525,7 @@ impl AstBuilder {
         let mut inner = pair.into_inner();
 
         // Pattern (shape)
-        let pattern = self.build_shape(inner.next().unwrap())?;
+        let pattern = self.build_shape(inner.next().expect("guaranteed by grammar"))?;
 
         // Optional guard and pipeline
         let mut guard = None;
@@ -1614,7 +1614,7 @@ impl AstBuilder {
     fn build_value(&mut self, pair: Pair<Rule>) -> Result<Value, ParseError> {
         debug_assert_eq!(pair.as_rule(), Rule::value);
 
-        let inner = pair.into_inner().next().unwrap();
+        let inner = pair.into_inner().next().expect("guaranteed by grammar");
         self.build_logical_or(inner)
     }
 
@@ -1698,7 +1698,7 @@ impl AstBuilder {
     fn build_comparison_op(&mut self, pair: Pair<Rule>) -> Result<BinOp, ParseError> {
         debug_assert_eq!(pair.as_rule(), Rule::comparison_op);
 
-        let inner = pair.into_inner().next().unwrap();
+        let inner = pair.into_inner().next().expect("guaranteed by grammar");
 
         match inner.as_rule() {
             Rule::eq_op => Ok(BinOp::Eq),
@@ -1778,11 +1778,11 @@ impl AstBuilder {
         debug_assert_eq!(pair.as_rule(), Rule::value_primary);
 
         let mut inner_iter = pair.into_inner();
-        let inner = inner_iter.next().unwrap();
+        let inner = inner_iter.next().expect("guaranteed by grammar");
 
         // Handle parenthesized expressions: lparen ~ value ~ rparen
         if inner.as_rule() == Rule::lparen {
-            let value_pair = inner_iter.next().unwrap();
+            let value_pair = inner_iter.next().expect("guaranteed by grammar");
             return self.build_value(value_pair);
         }
 
@@ -1822,7 +1822,7 @@ impl AstBuilder {
                 Ok(Value::String(s.to_string()))
             }
             Rule::bool => {
-                let inner2 = inner.into_inner().next().unwrap();
+                let inner2 = inner.into_inner().next().expect("guaranteed by grammar");
                 match inner2.as_rule() {
                     Rule::keyword_true => Ok(Value::Bool(true)),
                     Rule::keyword_false => Ok(Value::Bool(false)),
@@ -1838,7 +1838,7 @@ impl AstBuilder {
                 // Skip '@', 'global'
                 inner_pairs.next();
                 inner_pairs.next();
-                let ident = inner_pairs.next().unwrap().as_str().to_string();
+                let ident = inner_pairs.next().expect("guaranteed by grammar").as_str().to_string();
                 Ok(Value::Global(ident))
             }
             Rule::ident => Ok(Value::Name(inner.as_str().to_string())),
@@ -1978,10 +1978,10 @@ impl AstBuilder {
 
         let mut inner = pair.into_inner();
         inner.next(); // Skip '@'
-        let annotation_name = inner.next().unwrap(); // ident: "reduce" or "repeat"
+        let annotation_name = inner.next().expect("guaranteed by grammar"); // ident: "reduce" or "repeat"
         let name = annotation_name.as_str().to_string();
         inner.next(); // Skip '('
-        let arg = inner.next().unwrap(); // annotation_arg
+        let arg = inner.next().expect("guaranteed by grammar"); // annotation_arg
         let strategy = self.build_annotation_arg(arg)?;
         // Skip ')' (if present)
 
@@ -1996,7 +1996,7 @@ impl AstBuilder {
     fn build_annotation_arg(&mut self, pair: Pair<Rule>) -> Result<TransformStrategy, ParseError> {
         debug_assert_eq!(pair.as_rule(), Rule::annotation_arg);
 
-        let inner = pair.into_inner().next().unwrap();
+        let inner = pair.into_inner().next().expect("guaranteed by grammar");
 
         match inner.as_rule() {
             Rule::call_expr => {

--- a/src/grammar/mod.rs
+++ b/src/grammar/mod.rs
@@ -24,7 +24,7 @@ impl NeuroScriptParser {
             NeuroScriptParser::parse(Rule::program, source).map_err(error::from_pest_error)?;
 
         let mut builder = ast::AstBuilder::new();
-        builder.build_program(pairs.into_iter().next().unwrap())
+        builder.build_program(pairs.into_iter().next().expect("pest parse guarantees program rule"))
     }
 }
 

--- a/src/passes/contract_resolver.rs
+++ b/src/passes/contract_resolver.rs
@@ -662,7 +662,7 @@ fn resolve_match_in_endpoint(
                                 // Multi-endpoint pipeline: replace match with first endpoint
                                 // and return remaining endpoints for splicing
                                 let mut pipeline_iter = pipeline.into_iter();
-                                *endpoint = pipeline_iter.next().unwrap();
+                                *endpoint = pipeline_iter.next().expect("multi-endpoint pipeline has at least one element");
                                 let remaining: Vec<Endpoint> = pipeline_iter.collect();
                                 return (errors, Some(remaining));
                             }

--- a/src/shape/inference.rs
+++ b/src/shape/inference.rs
@@ -965,7 +965,7 @@ impl ShapeInferenceEngine {
                     .dims
                     .iter()
                     .position(|d| matches!(d, Dim::Variadic(_)))
-                    .unwrap(),
+                    .expect("has_variadic check guarantees variadic dim exists"),
                 concrete,
                 ctx,
             );

--- a/src/validator/core.rs
+++ b/src/validator/core.rs
@@ -359,13 +359,13 @@ impl Validator {
                         };
                         for name in unreachable_names {
                             errors.push(ValidationError::InvalidAnnotation {
-                                annotation: reshape.annotation.as_ref().unwrap().to_string(),
+                                annotation: reshape.annotation.as_ref().expect("checked by enclosing if-let").to_string(),
                                 reason: format!(
                                     "dimension '{}' in @reduce target shape is not defined in any input/output port shape or parameter of neuron '{}'",
                                     name, context_neuron
                                 ),
                                 context: format!("in {}", context_neuron),
-                                span: reshape.annotation.as_ref().unwrap().span(),
+                                span: reshape.annotation.as_ref().expect("checked by enclosing if-let").span(),
                             });
                         }
                     }
@@ -622,7 +622,7 @@ impl Validator {
 
         // Check exhaustiveness: last pattern should be a catch-all
         if !match_expr.arms.is_empty() {
-            let last_pattern = &match_expr.arms.last().unwrap().pattern;
+            let last_pattern = &match_expr.arms.last().expect("checked non-empty above").pattern;
             if let Some(shape) = last_pattern.as_shape() {
                 if !Self::is_catch_all_pattern(shape) {
                     errors.push(ValidationError::NonExhaustiveMatch {

--- a/src/validator/symbol_table.rs
+++ b/src/validator/symbol_table.rs
@@ -560,7 +560,7 @@ pub(super) fn check_port_compatibility(
                     let target_rank = reshape.dims.len();
                     if target_rank >= source_rank {
                         errors.push(ValidationError::InvalidAnnotation {
-                            annotation: format!("{}", reshape.annotation.as_ref().unwrap()),
+                            annotation: format!("{}", reshape.annotation.as_ref().expect("checked by enclosing if-let")),
                             reason: format!(
                                 "@reduce must decrease rank: source has {} dimensions but target has {}",
                                 source_rank, target_rank

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -170,7 +170,7 @@ fn find_entry_point(program: &Program) -> Option<String> {
     roots.sort();
 
     if !roots.is_empty() {
-        return Some(roots.last().unwrap().clone());
+        return Some(roots.last().expect("checked non-empty above").clone());
     }
 
     program


### PR DESCRIPTION
## Summary

- **Codegen (Phase 1):** Added `FormatError(#[from] std::fmt::Error)` variant to `CodegenError`. Replaced all `writeln!().unwrap()` with `?` operator across `forward.rs`, `generator.rs`, and `instantiation.rs` (~85 unwraps). Updated helper function return types to propagate `fmt::Result` / `Result<(), CodegenError>`.
- **AST builder (Phase 2):** Converted 57 `.next().unwrap()` calls to `.expect("guaranteed by grammar")` with updated module doc comment explaining the safety rationale.
- **Other modules (Phase 3):** Converted remaining production unwraps to `.expect()` with context messages in `validator/core.rs`, `validator/symbol_table.rs`, `shape/inference.rs`, `passes/contract_resolver.rs`, `codegen/utils.rs`, `grammar/mod.rs`, and `wasm.rs`.

**Result:** Non-test `unwrap()` calls reduced from ~150 to 0. All 342 unit tests + 31 integration tests pass.

## Test plan

- [x] `cargo check` passes
- [x] `cargo test` — all 342 unit tests pass
- [x] Integration/snapshot tests — all 31 pass
- [x] No new warnings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)